### PR TITLE
Mac support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ $ make CC=h5pcc
 A particular fluid model or data format can be specified with
 ```MODEL=model_name```. For all fluid data produced from Illinois codes after
 September 2018, the ```iharm``` model should be used -- this is the default if
-no model is specified.
+no model is specified.  After building a model, be sure to run
+```make clean``` before building a different one.
 
 The optional argument ```NOTES=``` can be any string containing no spaces.
 This string will be "baked-in" to the executable and printed out whenever the

--- a/README.md
+++ b/README.md
@@ -1,10 +1,31 @@
 # ipole
 Polarized covariant radiative transfer in C.
 
+# Prerequisites
+
+The only prerequisites are the GNU Scientific Library (GSL), and HDF5. Specifically,
+the executable ```h5cc``` should be in your ```PATH```.
+
+On Illinois BH cluster, this means loading the modules
+```bash
+$ module load gnu hdf5
+```
+
+On Linux machines, these can be installed to the system with
+```bash
+$ sudo things
+```
+
+The native macOS version of ```clang``` does not support OpenMP parallelization.  So,
+on macOS with ```brew```, install
+```bash
+$ brew install llvm gsl hdf5
+```
+these should all be binary packages, no compiling should be required.
+
 # Building
 
-The only prerequisite is HDF5, specifically the executable ```h5cc``` should 
-be in your ```PATH```. Then just build by running
+Then just build by running
 
 ```bash
 $ make

--- a/makefile
+++ b/makefile
@@ -21,6 +21,20 @@ MATH_LIB = -lm
 # Name of the executable
 EXE = ipole
 
+# Executable for MD5 sums
+MD5=md5sum
+
+# Overrides of the above for macOS
+ifneq (,$(findstring Darwin,$(shell uname)))
+	export HDF5_CC = /usr/local/opt/llvm/bin/clang
+	export HDF5_CLINKER = /usr/local/opt/llvm/bin/clang
+
+	GSL_DIR=/usr/local
+	SYSTEM_LIBDIR=
+
+	MD5=md5
+endif
+
 # Override these defaults if we know the machine we're working with
 # Once you know what compiles, add it as a machine def here
 MAKEFILE_PATH := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
@@ -89,9 +103,9 @@ endif
 default: build
 
 build: $(EXE)
-	@echo -e "Completed build with model: $(MODEL)"
-	@echo -e "CFLAGS: $(CFLAGS)"
-	@echo -e "MD5: $(shell md5sum $(EXE))"
+	@echo "Completed build with model: $(MODEL)"
+	@echo "CFLAGS: $(CFLAGS)"
+	@echo "MD5: $(shell $(MD5) $(EXE))"
 
 debug: CFLAGS += -g -Wall -Werror -Wno-unused-variable -Wno-unused-but-set-variable
 debug: CFLAGS += -DDEBUG=1
@@ -113,12 +127,12 @@ $(EXE): $(ARC_DIR)/$(EXE)
 	@cp $(ARC_DIR)/$(EXE) .
 
 $(ARC_DIR)/$(EXE): $(OBJ)
-	@echo -e "\tLinking $(EXE)"
+	@echo "\tLinking $(EXE)"
 	@$(LINK) $(LDFLAGS) $(OBJ) $(LIBDIR) $(LIB) -o $(ARC_DIR)/$(EXE)
 	@rm $(OBJ) # This ensures full recompile
 
 $(ARC_DIR)/%.o: $(ARC_DIR)/%.c $(HEAD_ARC)
-	@echo -e "\tCompiling $(notdir $<)"
+	@echo "\tCompiling $(notdir $<)"
 	@$(CC) $(CFLAGS) $(INC) -DVERSION=$(GIT_VERSION) -DNOTES=$(NOTES) -DMODEL=$(MODEL) -c $< -o $@
 
 $(ARC_DIR)/%: % | $(ARC_DIR)

--- a/makefile
+++ b/makefile
@@ -21,8 +21,9 @@ MATH_LIB = -lm
 # Name of the executable
 EXE = ipole
 
-# Executable for MD5 sums
+# Executables which apparently aren't standard
 MD5=md5sum
+ECHO=echo -e
 
 # Overrides of the above for macOS
 ifneq (,$(findstring Darwin,$(shell uname)))
@@ -33,6 +34,7 @@ ifneq (,$(findstring Darwin,$(shell uname)))
 	SYSTEM_LIBDIR=
 
 	MD5=md5
+	ECHO=echo
 endif
 
 # Override these defaults if we know the machine we're working with
@@ -103,9 +105,9 @@ endif
 default: build
 
 build: $(EXE)
-	@echo "Completed build with model: $(MODEL)"
-	@echo "CFLAGS: $(CFLAGS)"
-	@echo "MD5: $(shell $(MD5) $(EXE))"
+	@$(ECHO) "Completed build with model: $(MODEL)"
+	@$(ECHO) "CFLAGS: $(CFLAGS)"
+	@$(ECHO) "MD5: $(shell $(MD5) $(EXE))"
 
 debug: CFLAGS += -g -Wall -Werror -Wno-unused-variable -Wno-unused-but-set-variable
 debug: CFLAGS += -DDEBUG=1
@@ -120,19 +122,19 @@ vtune: build
 
 
 clean:
-	@echo "Cleaning build files..."
+	@$(ECHO) "Cleaning build files..."
 	@rm -f $(EXE) $(OBJ)
 
 $(EXE): $(ARC_DIR)/$(EXE)
 	@cp $(ARC_DIR)/$(EXE) .
 
 $(ARC_DIR)/$(EXE): $(OBJ)
-	@echo "\tLinking $(EXE)"
+	@$(ECHO) "\tLinking $(EXE)"
 	@$(LINK) $(LDFLAGS) $(OBJ) $(LIBDIR) $(LIB) -o $(ARC_DIR)/$(EXE)
 	@rm $(OBJ) # This ensures full recompile
 
 $(ARC_DIR)/%.o: $(ARC_DIR)/%.c $(HEAD_ARC)
-	@echo "\tCompiling $(notdir $<)"
+	@$(ECHO) "\tCompiling $(notdir $<)"
 	@$(CC) $(CFLAGS) $(INC) -DVERSION=$(GIT_VERSION) -DNOTES=$(NOTES) -DMODEL=$(MODEL) -c $< -o $@
 
 $(ARC_DIR)/%: % | $(ARC_DIR)

--- a/makefile
+++ b/makefile
@@ -123,7 +123,7 @@ vtune: build
 
 clean:
 	@$(ECHO) "Cleaning build files..."
-	@rm -f $(EXE) $(OBJ)
+	@rm -rf $(EXE) $(OBJ) $(ARC_DIR)
 
 $(EXE): $(ARC_DIR)/$(EXE)
 	@cp $(ARC_DIR)/$(EXE) .


### PR DESCRIPTION
Fixes #28, and handles compiling with 'brew' version of clang for OpenMP support but is otherwise minimally invasive/dependent.

Instructions+makefile work for me, and now one additional user, on macOS with brew.

Continues to work on personal Linux, Illinois BH machines, and Stampede.  If I can get a few additional confirmations that it hasn't broken any machines I think we should merge this soon, as current state on Mac is pretty broken.