### PR TITLE
Feature/sigmacut tools

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -194,7 +194,7 @@ void write_header(double scale, double cam[NDIM],
 
 void dump(double image[], double imageS[], double taus[],
     const char *fname, double scale, double cam[NDIM],
-    double fovx, double fovy, Params *params)
+    double fovx, double fovy, Params *params, int nopol)
 {
   hdf5_create(fname);
 
@@ -216,8 +216,8 @@ void dump(double image[], double imageS[], double taus[],
 
   hdf5_set_directory("/");
   // output stuff
-  hdf5_write_single_val(&Ftot, "Ftot", H5T_IEEE_F64LE);
   hdf5_write_single_val(&Ftot_unpol, "Ftot_unpol", H5T_IEEE_F64LE);
+  if (!nopol) hdf5_write_single_val(&Ftot, "Ftot", H5T_IEEE_F64LE);
   double nuLnu = 4. * M_PI * Ftot * dsource * dsource * JY * freqcgs;
   hdf5_write_single_val(&nuLnu, "nuLnu", H5T_IEEE_F64LE);
   nuLnu = 4. * M_PI * Ftot_unpol * dsource * dsource * JY * freqcgs;
@@ -227,7 +227,7 @@ void dump(double image[], double imageS[], double taus[],
   hsize_t pol_dim[3] = {nx, ny, NIMG};
   hdf5_write_full_array(image, "unpol", 2, unpol_dim, H5T_IEEE_F64LE);
   hdf5_write_full_array(taus, "tau", 2, unpol_dim, H5T_IEEE_F64LE);
-  hdf5_write_full_array(imageS, "pol", 3, pol_dim, H5T_IEEE_F64LE);
+  if (!nopol) hdf5_write_full_array(imageS, "pol", 3, pol_dim, H5T_IEEE_F64LE);
 
   // housekeeping
   hdf5_close();

--- a/src/io.h
+++ b/src/io.h
@@ -20,7 +20,7 @@ void read_restart(const char *fname, double *tA, double *tB, double *last_img_ta
 
 void dump(double image[], double imageS[], double taus[],
           const char *fname, double scale, double cam[NDIM],
-          double fovx, double fovy, Params *params);
+          double fovx, double fovy, Params *params, int nopol);
 void dump_var_along(int i, int j, int nstep, struct of_traj *traj, int nx, int ny,
                     double scale, double cam[NDIM], double fovx, double fovy, Params *params);
 

--- a/src/main.c
+++ b/src/main.c
@@ -424,7 +424,7 @@ int main(int argc, char *argv[])
           //fprintf(stderr, "saving image %d at t = %g\n", k, target_times[k]);
           char dfname[256];
           snprintf(dfname, 255, params.outf, target_times[k]);
-          dump(image, imageS, taus, dfname, scale, Xcam, fovx, fovy, &params);
+          dump(image, imageS, taus, dfname, scale, Xcam, fovx, fovy, &params, only_unpolarized);
           valid_images[k] = 0;
           nopenimgs--;
         }
@@ -642,7 +642,7 @@ int main(int argc, char *argv[])
     // like when fitting light curve fluxes
     if (!quench_output) {
       // dump result. if specified, also output ppm image
-      dump(image, imageS, taus, params.outf, scale, Xcam, fovx, fovy, &params);
+      dump(image, imageS, taus, params.outf, scale, Xcam, fovx, fovy, &params, only_unpolarized);
       if (params.add_ppm) {
         // TODO respect filename from params?
         make_ppm(image, freq, nx, ny, "ipole_lfnu.ppm");


### PR DESCRIPTION
- Adds sigma_cut and beta_crit as (model) parameters and outputs them to hdf5 image format.
- If the "-unpol" command line argument is supplied, image files will no longer contain polarized data. While this might introduce plotting complications, it results in significant disk space savings.