### PR TITLE
BHAC MKS Coordinates

### DIFF
--- a/model/iharm/model.c
+++ b/model/iharm/model.c
@@ -54,6 +54,7 @@ static double Ladv_dump;
 //    0 : constant TP_OVER_TE
 //    1 : use dump file model (kawazura?)
 //    2 : use mixed TP_OVER_TE (beta model)
+// TODO the way this is selected is horrid.  Make it a parameter.
 static int RADIATION, ELECTRONS;
 static double gam = 1.444444, game = 1.333333, gamp = 1.666667;
 static double Thetae_unit, Mdotedd;
@@ -210,15 +211,14 @@ void init_model(double *tA, double *tB)
   data[2] = &dataC;
 
   // set up grid for fluid data
-  fprintf(stderr, "reading data header...\n");
+  fprintf(stderr, "Reading data header...\n");
   init_iharm_grid(fnam, dumpmin);
-  fprintf(stderr, "success\n");
 
   // set all dimensional quantities from loaded parameters
   set_units();
 
   // read fluid data
-  fprintf(stderr, "reading data...\n");
+  fprintf(stderr, "Reading data...\n");
   load_iharm_data(0, fnam, dumpidx, 1);
   dumpidx += dumpskip;
   #if SLOW_LIGHT
@@ -228,7 +228,6 @@ void init_model(double *tA, double *tB)
   #else // FAST LIGHT
   data[2]->t =10000.;
   #endif // SLOW_LIGHT
-  fprintf(stderr, "success\n");
 
   // horizon radius
   Rh = 1 + sqrt(1. - a * a);
@@ -530,20 +529,26 @@ void init_iharm_grid(char *fnam, int dumpidx)
     exit(-3);
   }
 
-  char metric[20];
+  char metric_name[20];
   hid_t HDF5_STR_TYPE = hdf5_make_str_type(20);
-  hdf5_read_single_val(&metric, "metric", HDF5_STR_TYPE);
+  hdf5_read_single_val(&metric_name, "metric", HDF5_STR_TYPE);
 
-  METRIC_FMKS = 0;
-  METRIC_MKS3 = 0;
-  METRIC_eKS = 0;
+  metric = 0;
+  use_eKS_internal = 0;
 
-  if ( strncmp(metric, "MMKS", 19) == 0 ) {
-    METRIC_FMKS = 1;
-  } else if ( strncmp(metric, "MKS3", 19) == 0 ) {
-    METRIC_eKS = 1;
-    METRIC_MKS3 = 1;
-    fprintf(stderr, "using eKS metric with exotic \"MKS3\" zones...\n");
+  if ( strncmp(metric_name, "MKS", 19) == 0) {
+    metric = METRIC_MKS;
+  } else if ( strncmp(metric_name, "BHAC_MKS", 19) == 0) {
+    metric = METRIC_BHACMKS;
+  } else if ( strncmp(metric_name, "MMKS", 19) == 0 || strncmp(metric_name, "FMKS", 19) == 0) {
+    // TODO Handle MMKS vs FMKS signifiers in dumps somehow...
+    metric = METRIC_FMKS;
+  } else if ( strncmp(metric_name, "MKS3", 19) == 0 ) {
+    use_eKS_internal = 1;
+    metric = METRIC_MKS3;
+  } else {
+    fprintf(stderr, "File is in unknown metric %s.  Cannot continue.\n", metric_name);
+    exit(-1);
   }
 
   hdf5_read_single_val(&N1, "n1", H5T_STD_I32LE);
@@ -563,25 +568,25 @@ void init_iharm_grid(char *fnam, int dumpidx)
   // use of extra variables (instead of just UU and RHO) for thetae
   if (!USE_FIXED_TPTE && !USE_MIXED_TPTE) {
     if (ELECTRONS != 1) {
-      fprintf(stderr, "! no electron temperature model specified in model/iharm.c\n");
+      fprintf(stderr, "! no electron temperature model specified! Cannot continue\n");
       exit(-3);
     }
     ELECTRONS = 1;
     Thetae_unit = MP/ME;
   } else if (USE_FIXED_TPTE && !USE_MIXED_TPTE) {
     ELECTRONS = 0; // force TP_OVER_TE to overwrite bad electrons
-    fprintf(stderr, "using fixed tp_over_te ratio = %g\n", tp_over_te);
+    fprintf(stderr, "Using fixed tp_over_te ratio = %g\n", tp_over_te);
     //Thetae_unit = MP/ME*(gam-1.)*1./(1. + tp_over_te);
     // see, e.g., Eq. 8 of the EHT GRRT formula list. 
     // this formula assumes game = 4./3 and gamp = 5./3
     Thetae_unit = 2./3. * MP/ME / (2. + tp_over_te);
   } else if (USE_MIXED_TPTE && !USE_FIXED_TPTE) {
     ELECTRONS = 2;
-    fprintf(stderr, "using mixed tp_over_te with trat_small = %g, trat_large = %g, and beta_crit = %g\n", 
+    fprintf(stderr, "Using mixed tp_over_te with trat_small = %g, trat_large = %g, and beta_crit = %g\n", 
       trat_small, trat_large, beta_crit);
     // Thetae_unit set per-zone below
   } else {
-    fprintf(stderr, "! please change electron model in model/iharm.c\n");
+    fprintf(stderr, "Unknown electron model %d! Cannot continue.\n", ELECTRONS);
     exit(-3);
   }
   fprintf(stderr, "sigma_cut = %g\n", sigma_cut);
@@ -610,10 +615,27 @@ void init_iharm_grid(char *fnam, int dumpidx)
   hdf5_read_single_val(&dx[2], "dx2", H5T_IEEE_F64LE);
   hdf5_read_single_val(&dx[3], "dx3", H5T_IEEE_F64LE);
 
-  hdf5_set_directory("/header/geom/mks/");
-  if ( METRIC_FMKS ) hdf5_set_directory("/header/geom/mmks/");
-  if ( METRIC_MKS3 ) {
-    hdf5_set_directory("/header/geom/mks3/");
+  switch (metric) {
+    case METRIC_MKS:
+      hdf5_set_directory("/header/geom/mks/");
+      fprintf(stderr, "Using Modified Kerr-Schild coordinates MKS\n");
+      break;
+    case METRIC_BHACMKS:
+      hdf5_set_directory("/header/geom/bhac_mks/");
+      fprintf(stderr, "Using BHAC-style Modified Kerr-Schild coordinates BHAC_MKS\n");
+      break;
+    case METRIC_FMKS:
+      hdf5_set_directory("/header/geom/mmks/"); // For compat. TODO autodetect 'fmks' here?
+      fprintf(stderr, "Using Funky Modified Kerr-Schild coordinates FMKS\n");
+      break;
+    case METRIC_MKS3:
+      hdf5_set_directory("/header/geom/mks3/");
+      fprintf(stderr, "Using logarithmic KS coordinates internally\n");
+      fprintf(stderr, "Converting from KORAL-style Modified Kerr-Schild coordinates MKS3\n");
+      break;
+  }
+  
+  if ( metric == METRIC_MKS3 ) {
     hdf5_read_single_val(&a, "a", H5T_IEEE_F64LE);
     hdf5_read_single_val(&mks3R0, "R0", H5T_IEEE_F64LE);
     hdf5_read_single_val(&mks3H0, "H0", H5T_IEEE_F64LE);
@@ -621,7 +643,7 @@ void init_iharm_grid(char *fnam, int dumpidx)
     hdf5_read_single_val(&mks3MY2, "MY2", H5T_IEEE_F64LE);
     hdf5_read_single_val(&mks3MP0, "MP0", H5T_IEEE_F64LE);
     Rout = 100.; 
-  } else {
+  } else { // Some brand of MKS.  All have the same parameters
     hdf5_read_single_val(&a, "a", H5T_IEEE_F64LE);
     hdf5_read_single_val(&hslope, "hslope", H5T_IEEE_F64LE);
     if (hdf5_exists("Rin")) {
@@ -631,13 +653,14 @@ void init_iharm_grid(char *fnam, int dumpidx)
       hdf5_read_single_val(&Rin, "r_in", H5T_IEEE_F64LE);
       hdf5_read_single_val(&Rout, "r_out", H5T_IEEE_F64LE);
     }
+    fprintf(stderr, "MKS parameters a: %f hslope: %f Rin: %f Rout: %f\n", a, hslope, Rin, Rout);
 
-    if (METRIC_FMKS) {
-      fprintf(stderr, "custom refinement at poles loaded...\n");
+    if (metric == METRIC_FMKS) {
       hdf5_read_single_val(&poly_xt, "poly_xt", H5T_IEEE_F64LE);
       hdf5_read_single_val(&poly_alpha, "poly_alpha", H5T_IEEE_F64LE);
       hdf5_read_single_val(&mks_smooth, "mks_smooth", H5T_IEEE_F64LE);
       poly_norm = 0.5*M_PI*1./(1. + 1./(poly_alpha + 1.)*1./pow(poly_xt, poly_alpha));
+      fprintf(stderr, "MKS parameters poly_xt: %f poly_alpha: %f mks_smooth: %f poly_norm: %f\n", poly_xt, poly_alpha, mks_smooth, poly_norm);
     }
   }
 
@@ -653,8 +676,8 @@ void init_iharm_grid(char *fnam, int dumpidx)
   stopx[2] = startx[2]+N2*dx[2];
   stopx[3] = startx[3]+N3*dx[3];
 
-  fprintf(stderr, "start: %g %g %g \n", startx[1], startx[2], startx[3]);
-  fprintf(stderr, "stop: %g %g %g \n", stopx[1], stopx[2], stopx[3]);
+  fprintf(stderr, "Native coordinate start: %g %g %g stop: %g %g %g\n",
+                  startx[1], startx[2], startx[3], stopx[1], stopx[2], stopx[3]);
 
   init_storage();
   hdf5_close();
@@ -700,7 +723,6 @@ void load_iharm_data(int n, char *fnam, int dumpidx, int verbose)
   char fname[256];
   snprintf(fname, 255, fnam, dumpidx);
 
-  if (verbose) fprintf(stderr, "LOADING DATA\n");
   nloaded++;
 
   if ( hdf5_open(fname) < 0 ) {
@@ -910,7 +932,7 @@ void load_iharm_data(int n, char *fnam, int dumpidx, int verbose)
   MdotEdd_dump = Mdotedd;
   Ladv_dump =  Ladv;
 
-  if (verbose) {
+  if (verbose == 2) {
     fprintf(stderr,"dMact: %g [code]\n",dMact);
     fprintf(stderr,"Ladv: %g [code]\n",Ladv_dump);
     fprintf(stderr,"Mdot: %g [g/s] \n",Mdot_dump);
@@ -918,55 +940,19 @@ void load_iharm_data(int n, char *fnam, int dumpidx, int verbose)
     fprintf(stderr,"Mdot: %g [Mdotedd]\n",Mdot_dump/MdotEdd_dump);
     fprintf(stderr,"Mdotedd: %g [g/s]\n",MdotEdd_dump);
     fprintf(stderr,"Mdotedd: %g [MSUN/YR]\n",MdotEdd_dump/(MSUN/YEAR));
+  } else if (verbose == 1) {
+    fprintf(stderr,"Mdot: %g [MSUN/YR] \n",Mdot_dump/(MSUN / YEAR));
+    fprintf(stderr,"Mdot: %g [Mdotedd]\n",Mdot_dump/MdotEdd_dump);
   }
 
   // now construct useful scalar quantities (over full (+ghost) zones of data)
   init_physical_quantities(n);
-
-  // optionally calculate average beta weighted by jnu
-  if (0 == 1) {
-    #define NBETABINS 64.
-    double betabins[64] = { 0 };
-    #define BETAMIN (0.001)
-    #define BETAMAX (200.)
-    double dlBeta = (log(BETAMAX)-log(BETAMIN))/NBETABINS;
-    double BETA0 = log(BETAMIN);
-    double betajnugdet = 0.;
-    double jnugdet = 0.;
-    for (int i=1; i<N1+1; ++i) {
-      for (int j=1; j<N2+1; ++j) {
-        for (int k=1; k<N3+1; ++k) {
-          int zi = i-1; 
-          int zj = j-1;
-          int zk = k-1;
-          double bsq = 0.;
-          for (int l=0; l<4; ++l) bsq += data[n]->bcon[i][j][k][l]*data[n]->bcov[i][j][k][l];
-          double beta = data[n]->p[UU][i][j][k]*(gam-1.)/0.5/bsq;
-          double Ne = data[n]->ne[i][j][k];
-          double Thetae = data[n]->thetae[i][j][k];
-          double B = data[n]->b[i][j][k];
-          double jnu = jnu_synch(2.3e+11, Ne, Thetae, B, M_PI/3.);
-          double gdetzone = gdet_zone(zi,zj,zk);
-          betajnugdet += beta * jnu * gdetzone;
-          jnugdet += jnu * gdetzone;
-          int betai = (int) ( (log(beta) - BETA0) / dlBeta + 2.5 ) - 2;
-          betabins[betai] += jnu * gdetzone;
-        }
-      }
-    }
-    for (int i=0; i<NBETABINS; ++i) {
-      fprintf(stderr, "%d %g %g\n", i, exp(BETA0 + (i+0.5)*dlBeta), betabins[i]);
-    }
-    fprintf(stderr, "<beta> = %g\n", betajnugdet / jnugdet);
-  }
 }
 
 int radiating_region(double X[NDIM])
 {
-  if (X[1] > log(rmin_geo) && X[1] < log(rmax_geo) && X[2] > th_beg/M_PI && X[2] < (1.-th_beg/M_PI) ) {
-    return 1;
-  } else {
-    return 0;
-  }
+  double r, th;
+  bl_coord(X, &r, &th);
+  return (r > rmin_geo && r < rmax_geo && th > th_beg && th < (M_PI-th_beg));
 }
 

--- a/model/thin_disk/model.c
+++ b/model/thin_disk/model.c
@@ -61,10 +61,8 @@ void init_model(double *tA, double *tB)
 
   // Set all the geometry globals we need
   // TODO do this in geometry?  Deal with model/geom interface...
-  METRIC_eKS = 1;
-  METRIC_MKS = 0;
-  METRIC_FMKS = 0;
-  METRIC_MKS3 = 0;
+  use_eKS_internal = 1;
+  metric = 0; // Doesn't matter due to above
   hslope = 1.0;
 
   // We already set stuff from parameters, so set_units here

--- a/scripts/compare.py
+++ b/scripts/compare.py
@@ -1,0 +1,82 @@
+"""
+  Compare two images and quantify their differences
+"""
+
+import numpy as np
+import h5py
+import sys
+
+def blur(im, fwhm=20):
+    # 20uas FWHM Gaussian blur. Assume 1px/uas
+    return gaussian_filter(im, sigma=(fwhm / (2 * np.sqrt(2 * np.log(2)))))
+
+# Statistics functions
+def mse(image1, image2):
+    """MSE of image1 vs image2.  As in GRRT paper definition of said, divides by image1 sum"""
+    # Avoid dividing by 0
+    norm = np.sum(np.abs(image1)**2)
+    if norm == 0: norm = 1
+
+    return np.sum(np.abs(image1 - image2)**2) / norm
+
+def ssim(imageI, imageK):
+    """SSIM as defined in Gold et al eq 10-ish"""
+    N = imageI.shape[0] * imageI.shape[1]
+    mu_I = np.sum(imageI) / N
+    mu_K = np.sum(imageK) / N
+    sig2_I = np.sum((imageI - mu_I)**2) / (N-1)
+    sig2_K = np.sum((imageK - mu_K)**2) / (N-1)
+    sig_IK = np.sum((imageI - mu_I)*(imageK - mu_K)) / (N-1)
+    return (2*mu_I*mu_K) / (mu_I**2 + mu_K**2) * (2*sig_IK) / (sig2_I + sig2_K)
+
+def dssim(imageI, imageK):
+    tssim = ssim(imageI, imageK)
+    if np.isnan(tssim):
+        return 0.0
+    else:
+        return 1/np.abs(tssim) - 1
+
+if __name__ == "__main__":
+    fname1 = sys.argv[1]
+    fname2 = sys.argv[2]
+    print("Comparing {} vs {}".format(fname1, fname2))
+
+    # load
+    with h5py.File(fname1,'r') as hfp:
+      unpol1 = np.copy(hfp['unpol']).transpose((1,0))
+      imagep = np.copy(hfp['pol']).transpose((1,0,2))
+      I1 = imagep[:,:,0]
+      Q1 = imagep[:,:,1]
+      U1 = imagep[:,:,2]
+      V1 = imagep[:,:,3]
+    with h5py.File(fname2,'r') as hfp:
+      unpol2 = np.copy(hfp['unpol']).transpose((1,0))
+      imagep = np.copy(hfp['pol']).transpose((1,0,2))
+      I2 = imagep[:,:,0]
+      Q2 = imagep[:,:,1]
+      U2 = imagep[:,:,2]
+      V2 = imagep[:,:,3]
+
+    # command line output
+    print("Images\t\tMSE\t\tDSSIM\t\tabs flux diff\trel flux diff")
+    mseu = mse(unpol1, unpol2); dssimu = dssim(unpol1, unpol2); diffu = unpol2.sum() - unpol1.sum(); rdiffu = (unpol2.sum() - unpol1.sum())/unpol1.sum()
+    print("Unpolarized:\t{:.7g}\t{:.7g}\t{:.7g}\t{:.7g}".format(mseu, dssimu, diffu, rdiffu))
+    mseI = mse(I1, I2); dssimI = dssim(I1, I2); diffI = I2.sum() - I1.sum(); rdiffI = (I2.sum() - I1.sum())/I1.sum()
+    print("Stokes I:\t{:.7g}\t{:.7g}\t{:.7g}\t{:.7g}".format(mseI, dssimI, diffI, rdiffI))
+    mseQ = mse(Q1, Q2); dssimQ = dssim(Q1, Q2); diffQ = Q2.sum() - Q1.sum(); rdiffQ = (Q2.sum() - Q1.sum())/Q1.sum()
+    print("Stokes Q:\t{:.7g}\t{:.7g}\t{:.7g}\t{:.7g}".format(mseQ, dssimQ, diffQ, rdiffQ))
+    mseU = mse(U1, U2); dssimU = dssim(U1, U2); diffU = U2.sum() - U1.sum(); rdiffU = (U2.sum() - U1.sum())/U1.sum()
+    print("Stokes U:\t{:.7g}\t{:.7g}\t{:.7g}\t{:.7g}".format(mseU, dssimU, diffU, rdiffU))
+    mseV = mse(V1, V2); dssimV = dssim(V1, V2); diffV = V2.sum() - V1.sum(); rdiffV = (V2.sum() - V1.sum())/V1.sum()
+    print("Stokes V:\t{:.7g}\t{:.7g}\t{:.7g}\t{:.7g}".format(mseV, dssimV, diffV, rdiffV))
+
+    lp1 = 100.*np.sqrt(Q1.sum()**2+U1.sum()**2)/I1.sum()
+    lp2 = 100.*np.sqrt(Q2.sum()**2+U2.sum()**2)/I2.sum()
+    print("Diff LP [%]: {:g}".format(lp2 - lp1))
+    cp1 = 100.*V1.sum()/I1.sum()
+    cp2 = 100.*V2.sum()/I2.sum()
+    print("Diff CP [%]: {:g}".format(cp2 - cp1))
+    evpatot1 = 180./3.14159*0.5*np.arctan2(U1.sum(),Q1.sum())
+    evpatot2 = 180./3.14159*0.5*np.arctan2(U2.sum(),Q2.sum())
+    print("Diff EVPA [deg]: {:g}".format(evpatot2 - evpatot1))
+

--- a/scripts/plot_pol.py
+++ b/scripts/plot_pol.py
@@ -8,7 +8,8 @@ $ python ipole_plot.py path/to/images/*h5
 $ ffmpeg -framerate 8 -i dump%*.png -s:v 1280x720 -c:v libx264 -profile:v high -crf 20 -pix_fmt yuv420p out.mp4
 
 """
-
+import matplotlib
+matplotlib.use("agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import h5py
@@ -27,13 +28,13 @@ EVPA_CONV = "EofN"  # can be set fo "EofN" or "NofW"
 ## no need to touch anything below this line
 
 def colorbar(mappable):
-    """ the way matplotlib colorbar should have been implemented """
-    from mpl_toolkits.axes_grid1 import make_axes_locatable
-    ax = mappable.axes
-    fig = ax.figure
-    divider = make_axes_locatable(ax)
-    cax = divider.append_axes("right", size="5%", pad=0.05)
-    return fig.colorbar(mappable, cax=cax)
+  """ the way matplotlib colorbar should have been implemented """
+  from mpl_toolkits.axes_grid1 import make_axes_locatable
+  ax = mappable.axes
+  fig = ax.figure
+  divider = make_axes_locatable(ax)
+  cax = divider.append_axes("right", size="5%", pad=0.05)
+  return fig.colorbar(mappable, cax=cax)
 
 if __name__ == "__main__":
 

--- a/src/coordinates.c
+++ b/src/coordinates.c
@@ -5,10 +5,10 @@
 #include "decs.h"
 #include "geometry.h"
 
-int METRIC_eKS;
-int METRIC_MKS, METRIC_FMKS, METRIC_MKS3;
-double a, hslope;
-double poly_norm, poly_xt, poly_alpha, mks_smooth; // mmks
+int use_eKS_internal;
+int metric;
+double a, hslope; // mks
+double poly_norm, poly_xt, poly_alpha, mks_smooth; // fmks
 double mks3R0, mks3H0, mks3MY1, mks3MY2, mks3MP0; // mks3
 double startx[NDIM], stopx[NDIM], dx[NDIM];
 double R0, Rin, Rout, Rh;
@@ -20,31 +20,40 @@ double R0, Rin, Rout, Rh;
  */
 void bl_coord(double X[NDIM], double *r, double *th)
 {
-  *r = exp(X[1]);
+  *r = exp(X[1]);  // Note: Overridden by one case below
 
-  if (METRIC_eKS) {
-    *r = exp(X[1]);
+  if (use_eKS_internal) {
     *th = M_PI * X[2];
-  } else if (METRIC_MKS3) {
-    *r = exp(X[1]) + mks3R0;
-    *th = (M_PI
-        * (1.
-            + 1. / tan((mks3H0 * M_PI) / 2.)
-                * tan(
-                    mks3H0 * M_PI
-                        * (-0.5
-                            + (mks3MY1
-                                + (pow(2., mks3MP0) * (-mks3MY1 + mks3MY2))
-                                    / pow(exp(X[1]) + mks3R0, mks3MP0))
-                                * (1. - 2. * X[2]) + X[2])))) / 2.;
-  } else if (METRIC_FMKS) {
-    double thG = M_PI * X[2] + ((1. - hslope) / 2.) * sin(2. * M_PI * X[2]);
-    double y = 2 * X[2] - 1.;
-    double thJ = poly_norm * y
-        * (1. + pow(y / poly_xt, poly_alpha) / (poly_alpha + 1.)) + 0.5 * M_PI;
-    *th = thG + exp(mks_smooth * (startx[1] - X[1])) * (thJ - thG);
   } else {
-    *th = M_PI * X[2] + ((1. - hslope) / 2.) * sin(2. * M_PI * X[2]);
+    double y, thG, thJ;
+    switch (metric) {
+      case METRIC_MKS:
+        *th = M_PI * X[2] + ((1. - hslope) / 2.) * sin(2. * M_PI * X[2]);
+        break;
+      case METRIC_BHACMKS:
+        *th = X[2] + (hslope / 2.) * sin(2. * X[2]);
+        break;
+      case METRIC_FMKS:
+        thG = M_PI * X[2] + ((1. - hslope) / 2.) * sin(2. * M_PI * X[2]);
+        y = 2 * X[2] - 1.;
+        thJ = poly_norm * y
+            * (1. + pow(y / poly_xt, poly_alpha) / (poly_alpha + 1.)) + 0.5 * M_PI;
+        *th = thG + exp(mks_smooth * (startx[1] - X[1])) * (thJ - thG);
+        break;
+      case METRIC_MKS3:
+        *r = exp(X[1]) + mks3R0;
+        *th = (M_PI
+            * (1.
+                + 1. / tan((mks3H0 * M_PI) / 2.)
+                    * tan(
+                        mks3H0 * M_PI
+                            * (-0.5
+                                + (mks3MY1
+                                    + (pow(2., mks3MP0) * (-mks3MY1 + mks3MY2))
+                                        / pow(exp(X[1]) + mks3R0, mks3MP0))
+                                    * (1. - 2. * X[2]) + X[2])))) / 2.;
+        break;
+    }
   }
 }
 
@@ -166,85 +175,76 @@ void set_dxdX(double X[NDIM], double dxdX[NDIM][NDIM])
   // Jacobian with respect to KS basis where X is given in
   // non-KS basis
   MUNULOOP
-    dxdX[mu][nu] = 0.;
+    dxdX[mu][nu] = delta(mu, nu);
 
-  if (METRIC_eKS) { //  && metric == 0 // TODO eKS switch
-    dxdX[0][0] = 1.;
-    dxdX[1][1] = exp(X[1]);
+  dxdX[1][1] = exp(X[1]);
+
+  if (use_eKS_internal) { //  && metric == 0 // TODO eKS switch
     dxdX[2][2] = M_PI;
-    dxdX[3][3] = 1.;
-
-  } else if (METRIC_MKS3) {
-
-    // mks3 ..
-    dxdX[0][0] = 1.;
-    dxdX[1][1] = exp(X[1]);
-    dxdX[2][1] = -(pow(2., -1. + mks3MP0) * exp(X[1]) * mks3H0 * mks3MP0
-        * (mks3MY1 - mks3MY2) * pow(M_PI, 2)
-        * pow(exp(X[1]) + mks3R0, -1 - mks3MP0) * (-1 + 2 * X[2]) * 1.
-        / tan((mks3H0 * M_PI) / 2.)
-        * pow(
-            1.
-                / cos(
-                    mks3H0 * M_PI
-                        * (-0.5
-                            + (mks3MY1
-                                + (pow(2, mks3MP0) * (-mks3MY1 + mks3MY2))
-                                    / pow(exp(X[1]) + mks3R0, mks3MP0))
-                                * (1 - 2 * X[2]) + X[2])),
-            2));
-    dxdX[2][2] = (mks3H0 * pow(M_PI, 2)
-        * (1
-            - 2
-                * (mks3MY1
-                    + (pow(2, mks3MP0) * (-mks3MY1 + mks3MY2))
-                        / pow(exp(X[1]) + mks3R0, mks3MP0))) * 1.
-        / tan((mks3H0 * M_PI) / 2.)
-        * pow(
-            1.
-                / cos(
-                    mks3H0 * M_PI
-                        * (-0.5
-                            + (mks3MY1
-                                + (pow(2, mks3MP0) * (-mks3MY1 + mks3MY2))
-                                    / pow(exp(X[1]) + mks3R0, mks3MP0))
-                                * (1 - 2 * X[2]) + X[2])),
-            2)) / 2.;
-    dxdX[3][3] = 1.;
-
-  } else if (METRIC_FMKS) {
-
-    // fmks
-    dxdX[0][0] = 1.;
-    dxdX[1][1] = exp(X[1]);
-    dxdX[2][1] = -exp(mks_smooth * (startx[1] - X[1])) * mks_smooth
-        * (
-        M_PI / 2. -
-        M_PI * X[2]
-            + poly_norm * (2. * X[2] - 1.)
-                * (1
-                    + (pow((-1. + 2 * X[2]) / poly_xt, poly_alpha))
-                        / (1 + poly_alpha))
-            - 1. / 2. * (1. - hslope) * sin(2. * M_PI * X[2]));
-    dxdX[2][2] = M_PI + (1. - hslope) * M_PI * cos(2. * M_PI * X[2])
-        + exp(mks_smooth * (startx[1] - X[1]))
-            * (-M_PI
-                + 2. * poly_norm
-                    * (1.
-                        + pow((2. * X[2] - 1.) / poly_xt, poly_alpha)
-                            / (poly_alpha + 1.))
-                + (2. * poly_alpha * poly_norm * (2. * X[2] - 1.)
-                    * pow((2. * X[2] - 1.) / poly_xt, poly_alpha - 1.))
-                    / ((1. + poly_alpha) * poly_xt)
-                - (1. - hslope) * M_PI * cos(2. * M_PI * X[2]));
-    dxdX[3][3] = 1.;
-
   } else {
-    // mks
-    dxdX[0][0] = 1.;
-    dxdX[1][1] = exp(X[1]);
-    dxdX[2][2] = M_PI - (hslope - 1.) * M_PI * cos(2. * M_PI * X[2]);
-    dxdX[3][3] = 1.;
+    switch (metric) {
+      case METRIC_MKS:
+        dxdX[2][2] = M_PI + (1 - hslope) * M_PI * cos(2. * M_PI * X[2]);
+        break;
+      case METRIC_BHACMKS:
+        dxdX[2][2] = 1 + hslope * cos(2. * X[2]);
+        break;
+      case METRIC_FMKS:
+        dxdX[2][1] = -exp(mks_smooth * (startx[1] - X[1])) * mks_smooth
+            * (
+            M_PI / 2. -
+            M_PI * X[2]
+                + poly_norm * (2. * X[2] - 1.)
+                    * (1
+                        + (pow((-1. + 2 * X[2]) / poly_xt, poly_alpha))
+                            / (1 + poly_alpha))
+                - 1. / 2. * (1. - hslope) * sin(2. * M_PI * X[2]));
+        dxdX[2][2] = M_PI + (1. - hslope) * M_PI * cos(2. * M_PI * X[2])
+            + exp(mks_smooth * (startx[1] - X[1]))
+                * (-M_PI
+                    + 2. * poly_norm
+                        * (1.
+                            + pow((2. * X[2] - 1.) / poly_xt, poly_alpha)
+                                / (poly_alpha + 1.))
+                    + (2. * poly_alpha * poly_norm * (2. * X[2] - 1.)
+                        * pow((2. * X[2] - 1.) / poly_xt, poly_alpha - 1.))
+                        / ((1. + poly_alpha) * poly_xt)
+                    - (1. - hslope) * M_PI * cos(2. * M_PI * X[2]));
+        break;
+      case METRIC_MKS3:
+        dxdX[2][1] = -(pow(2., -1. + mks3MP0) * exp(X[1]) * mks3H0 * mks3MP0
+            * (mks3MY1 - mks3MY2) * pow(M_PI, 2)
+            * pow(exp(X[1]) + mks3R0, -1 - mks3MP0) * (-1 + 2 * X[2]) * 1.
+            / tan((mks3H0 * M_PI) / 2.)
+            * pow(
+                1.
+                    / cos(
+                        mks3H0 * M_PI
+                            * (-0.5
+                                + (mks3MY1
+                                    + (pow(2, mks3MP0) * (-mks3MY1 + mks3MY2))
+                                        / pow(exp(X[1]) + mks3R0, mks3MP0))
+                                    * (1 - 2 * X[2]) + X[2])),
+                2));
+        dxdX[2][2] = (mks3H0 * pow(M_PI, 2)
+            * (1
+                - 2
+                    * (mks3MY1
+                        + (pow(2, mks3MP0) * (-mks3MY1 + mks3MY2))
+                            / pow(exp(X[1]) + mks3R0, mks3MP0))) * 1.
+            / tan((mks3H0 * M_PI) / 2.)
+            * pow(
+                1.
+                    / cos(
+                        mks3H0 * M_PI
+                            * (-0.5
+                                + (mks3MY1
+                                    + (pow(2, mks3MP0) * (-mks3MY1 + mks3MY2))
+                                        / pow(exp(X[1]) + mks3R0, mks3MP0))
+                                    * (1 - 2 * X[2]) + X[2])),
+                2)) / 2.;
+        break;
+    }
   }
 }
 
@@ -270,8 +270,8 @@ void vec_from_ks(double X[NDIM], double v_ks[NDIM], double v_nat[NDIM]) {
   MUNULOOP v_nat[mu] += dXdx[mu][nu] * v_ks[nu];
 }
 
-// Root-find the camera location in native coordinates
-double root_find(double X[NDIM])
+// Root-find the camera x2 location in native coordinates
+double root_find(double X[NDIM], double startx2, double stopx2)
 {
   double th = X[2];
   double tha, thb, thc;
@@ -285,11 +285,11 @@ double root_find(double X[NDIM])
   Xc[3] = Xa[3];
 
   if (X[2] < M_PI / 2.) {
-    Xa[2] = 0.;
-    Xb[2] = 0.5 + SMALL;
+    Xa[2] = startx2;
+    Xb[2] = (stopx2 - startx2)/2 + SMALL;
   } else {
-    Xa[2] = 0.5 - SMALL;
-    Xb[2] = 1.;
+    Xa[2] = (stopx2 - startx2)/2 - SMALL;
+    Xb[2] = stopx2;
   }
 
   double tol = 1.e-9;

--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -3,10 +3,22 @@
 
 #include "decs.h"
 
-extern int METRIC_eKS;
-extern int METRIC_MKS, METRIC_FMKS, METRIC_MKS3;
-extern double a, hslope;
-extern double poly_norm, poly_xt, poly_alpha, mks_smooth; // mmks
+// Poor man's enum of coordinate systems
+// Modified Kerr-Schild coordinates.  Gammie '03.
+#define METRIC_MKS 0
+// New-style BHAC MKS.  Just like MKS but with X2 in [0,pi] and hslope->(1-hslope)
+#define METRIC_BHACMKS 1
+// "Funky" MKS coordinates as defined on IL wiki, see
+// https://github.com/AFD-Illinois/docs/wiki/Coordinates
+#define METRIC_FMKS 2
+// MKS3 coordinates from koral-light
+#define METRIC_MKS3 3
+
+// Coordinate parameters.  See 
+extern int use_eKS_internal;
+extern int metric;
+extern double a, hslope; // mks
+extern double poly_norm, poly_xt, poly_alpha, mks_smooth; // fmks
 extern double mks3R0, mks3H0, mks3MY1, mks3MY2, mks3MP0; // mks3
 extern double startx[NDIM], stopx[NDIM], dx[NDIM];
 extern double R0, Rin, Rout, Rh;
@@ -24,6 +36,6 @@ void set_dXdx(double X[NDIM], double dXdx[NDIM][NDIM]);
 void vec_to_ks(double X[NDIM], double v_nat[NDIM], double v_ks[NDIM]);
 void vec_from_ks(double X[NDIM], double v_ks[NDIM], double v_nat[NDIM]);
 
-double root_find(double X[NDIM]);
+double root_find(double X[NDIM], double startx2, double stopx2);
 
 #endif // COORDINATES_H

--- a/src/main.c
+++ b/src/main.c
@@ -103,10 +103,9 @@ int main(int argc, char *argv[])
   double x[NDIM] = {0., rcam, thetacam/180.*M_PI, phicam/180.*M_PI};
   Xcam[0] = 0.0;
   Xcam[1] = log(rcam);
-  Xcam[2] = root_find(x);
-  Xcam[3] = phicam/180.*M_PI;
+  Xcam[2] = root_find(x, startx[2], stopx[2]);
+  Xcam[3] = phicam/180.*M_PI; // This will need to be changed for future coordinates
   fprintf(stderr, "Xcam[] = %e %e %e %e\n", Xcam[0], Xcam[1], Xcam[2], Xcam[3]);
-  fprintf(stderr, "a=%g R0=%g hslope=%g\n", a, R0, hslope);
 
   params.dsource *= PC;
   double Dsource = params.dsource; // Shorthand
@@ -137,13 +136,13 @@ int main(int argc, char *argv[])
   fovy = DY / rcam;
 
   scale = (DX * L_unit / nx) * (DY * L_unit / ny) / (Dsource * Dsource) / JY;
-  fprintf(stderr,"L_unit = %e DX = %e NX = %i Dsource = %e JY = %e\n", L_unit, DX, nx, Dsource,JY);
   fprintf(stderr,"intensity [cgs] to flux per pixel [Jy] conversion: %g\n",scale);
   fprintf(stderr,"Dsource: %g [cm]\n",Dsource);
   fprintf(stderr,"Dsource: %g [kpc]\n",Dsource/(1.e3*PC));
   fprintf(stderr,"FOVx, FOVy: %g %g [GM/c^2]\n",DX,DY);
   fprintf(stderr,"FOVx, FOVy: %g %g [rad]\n",DX*L_unit/Dsource,DY*L_unit/Dsource);
   fprintf(stderr,"FOVx, FOVy: %g %g [muas]\n",DX*L_unit/Dsource * 2.06265e11 ,DY*L_unit/Dsource * 2.06265e11);
+  fprintf(stderr,"NX = %i NY = %i\n", nx, ny);
 
   // slow light
   if (SLOW_LIGHT) {
@@ -191,7 +190,7 @@ int main(int argc, char *argv[])
 
         MULOOP Xhalf[mu] = X[mu];
         while (!stop_backward_integration(X, Xhalf, Kcon, Xcam)) {
-          dl = stepsize(X, Kcon);
+          dl = stepsize(X, Kcon, stopx[2]);
           push_photon(X, Kcon, -dl, Xhalf, Kconhalf);
           nstep++;
 
@@ -242,7 +241,7 @@ int main(int argc, char *argv[])
 
         MULOOP Xhalf[mu] = X[mu];
         while (!stop_backward_integration(X, Xhalf, Kcon, Xcam)) {
-          dl = stepsize(X, Kcon);
+          dl = stepsize(X, Kcon, stopx[2]);
           push_photon(X, Kcon, -dl, Xhalf, Kconhalf);
           nstep++;
 
@@ -470,7 +469,7 @@ int main(int argc, char *argv[])
         while (!stop_backward_integration(X, Xhalf, Kcon, Xcam)) {
           /* This stepsize function can be troublesome inside of R = 2M,
              and should be used cautiously in this region. */
-          dl = stepsize(X, Kcon);
+          dl = stepsize(X, Kcon, stopx[2]);
 
           /* move photon one step backwards, the procecure updates X
              and Kcon full step and returns also values in the middle */

--- a/src/model_geodesics.c
+++ b/src/model_geodesics.c
@@ -45,7 +45,7 @@ int stop_backward_integration(double X[NDIM], double Xhalf[NDIM], double Kcon[ND
   return (0);
 }
 
-double stepsize(double X[NDIM], double Kcon[NDIM])
+double stepsize(double X[NDIM], double Kcon[NDIM], double stopx2)
 {
   double eps = 0.01; // TODO take as parameter w/MAXNSTEP?
 
@@ -54,7 +54,7 @@ double stepsize(double X[NDIM], double Kcon[NDIM])
 
   dlx1 = eps / (fabs(Kcon[1]) + SMALL*SMALL) ;
   //dlx2 = EPS * GSL_MIN(X[2], 1. - X[2]) / (fabs(Kcon[2]) + SMALL*SMALL) ;
-  dlx2 = eps * MIN(X[2], 1. - X[2]) / (fabs(Kcon[2]) + SMALL*SMALL) ;
+  dlx2 = eps * MIN(X[2], stopx2 - X[2]) / (fabs(Kcon[2]) + SMALL*SMALL) ;
   dlx3 = eps / (fabs(Kcon[3]) + SMALL*SMALL) ;
 
   idlx1 = 1./(fabs(dlx1) + SMALL*SMALL) ;

--- a/src/model_geodesics.h
+++ b/src/model_geodesics.h
@@ -11,6 +11,6 @@
 #include "decs.h"
 
 int stop_backward_integration(double X[NDIM], double Xhalf[NDIM], double Kcon[NDIM], double Xcam[NDIM]);
-double stepsize(double X[NDIM], double K[NDIM]);
+double stepsize(double X[NDIM], double K[NDIM], double stopx2);
 
 #endif /* SRC_MODEL_GEODESICS_H_ */

--- a/src/model_tetrads.c
+++ b/src/model_tetrads.c
@@ -78,8 +78,8 @@ void make_plasma_tetrad(double Ucon[NDIM], double Kcon[NDIM], double Bcon[NDIM],
 
   // less restrictive condition on geometry for eKS coordinates which are
   // used when the exotic is expected.
-  if ((fabs(fabs(dot) - 1.) > 1.e-10 && METRIC_eKS == 0)
-      || (fabs(fabs(dot) - 1.) > 1.e-7 && METRIC_eKS == 1)) {
+  if ((fabs(fabs(dot) - 1.) > 1.e-10 && use_eKS_internal == 0)
+      || (fabs(fabs(dot) - 1.) > 1.e-7 && use_eKS_internal == 1)) {
     fprintf(stderr, "that's odd: %g\n", fabs(dot) - 1.);
     fprintf(stderr, "Ucon[] = %e %e %e %e\n", Ucon[0], Ucon[1], Ucon[2],
             Ucon[3]);

--- a/tests/clean_tests.sh
+++ b/tests/clean_tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+rm -rf */ipole */build_archive
+rm */image.h5 */*.png */out_*.txt

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -12,10 +12,10 @@ do
   folder=${folder: : -1}
   if [[ "$folder" != "test-resources" ]]; then
     cd $folder
-    if [[ $folder == *"sample_dump"* ]]; then
-      make -f ../../makefile -j8 MODEL=iharm
-    else
+    if [[ $folder == *"thin_disk"* ]]; then
       make -f ../../makefile -j8 MODEL=thin_disk
+    else
+      make -f ../../makefile -j8 MODEL=iharm
     fi
     ./ipole -par $folder.par &> out_$folder.txt
     ../verify.sh

--- a/tests/sample_dump_bhacmks/sample_dump_bhacmks.par
+++ b/tests/sample_dump_bhacmks/sample_dump_bhacmks.par
@@ -1,0 +1,18 @@
+# ipole parameter file for Polarized GRRT comparison
+
+dump ../test-resources/sample_dump_SANE_a+0.97_bhacmks_0500.h5
+
+rcam 1.e4
+thetacam 163
+phicam 0
+
+fovx_dsource 160
+fovy_dsource 160
+
+freqcgs 230.e9
+trat_small 3
+trat_large 3
+
+MBH 6.2e9
+M_unit 7.5e26
+outfile image.h5

--- a/tests/sample_dump_mks/sample_dump_mks.par
+++ b/tests/sample_dump_mks/sample_dump_mks.par
@@ -1,0 +1,18 @@
+# ipole parameter file for Polarized GRRT comparison
+
+dump ../test-resources/sample_dump_SANE_a+0.94_MKS_0900.h5
+
+rcam 1.e4
+thetacam 163
+phicam 0
+
+fovx_dsource 160
+fovy_dsource 160
+
+freqcgs 230.e9
+trat_small 3
+trat_large 3
+
+MBH 6.2e9
+M_unit 1.672e26
+outfile image.h5

--- a/tests/verify.sh
+++ b/tests/verify.sh
@@ -5,21 +5,9 @@
 
 folder=$(basename $PWD)
 
-echo "ABSOLUTE 1e-3"
-h5diff -d 1.e-3 image.h5 ../test-resources/$folder.h5 /pol
-echo "ABSOLUTE 1e-5"
-h5diff -d 1.e-5 image.h5 ../test-resources/$folder.h5 /pol
-echo "ABSOLUTE 1e-8"
-h5diff -d 1.e-8 image.h5 ../test-resources/$folder.h5 /pol
-echo ""
-echo ""
-echo "RELATIVE 1e-3"
-h5diff -p 1.e-3 image.h5 ../test-resources/$folder.h5 /pol
-echo "RELATIVE 1e-5"
-h5diff -p 1.e-5 image.h5 ../test-resources/$folder.h5 /pol
-echo "RELATIVE 1e-8"
-h5diff -p 1.e-8 image.h5 ../test-resources/$folder.h5 /pol
+echo "Pixels different by >1% absolute"
+h5diff -d 1.e-2 ../test-resources/${folder}_image.h5 image.h5 /pol
+echo "Pixels different by >1% relative"
+h5diff -p 1.e-2 ../test-resources/${folder}_image.h5 iamge.h5 /pol
 
-python ../../scripts/plot_pol.py image.h5 > plot_img.txt
-python ../../scripts/plot_pol.py ../test-resources/$folder.h5 > plot_ref.txt
-diff plot_img.txt plot_ref.txt
+python ../../scripts/compare.py ../test-resources/${folder}_image.h5 image.h5


### PR DESCRIPTION
BHAC uses a slightly different flavor of MKS coordinates, with
x2 -> pi*x2
hslope -> (1-hslope)

And while this trivial a conversion could be done in-place pretty easily with our python tooling, ipole's support for coordinates needed some love, so I figured I'd do it the right way^(TM).

So, between improving printed output, coordinate system selection, and tests, and rooting out a bunch of places ipole implicitly assumes x2 is in [0,1], ipole got better, and I lost a day.