### PR TITLE
Even adaptive resolution

### DIFF
--- a/model/iharm/example.par
+++ b/model/iharm/example.par
@@ -13,6 +13,8 @@ rotcam 0
 # Pixels in x,y dimension
 nx 160
 ny 160
+nx_min 40
+ny_min 40
 
 # Distance to source in parsec
 dsource 16.9e6
@@ -82,7 +84,7 @@ yoff 0
 # PATH-TRACE PARAMETERS
 
 # Whether to save GRMHD variables along some paths
-trace 1
+trace 0
 # Pixel to trace i,j (rightward from left, upward from bottom)
 #trace_i 40
 #trace_j 40

--- a/src/io.h
+++ b/src/io.h
@@ -20,7 +20,7 @@ void read_restart(const char *fname, double *tA, double *tB, double *last_img_ta
 
 void dump(double image[], double imageS[], double taus[],
           const char *fname, double scale, double cam[NDIM],
-          double fovx, double fovy, Params *params, int nopol);
+          double fovx, double fovy, int nx, int ny, Params *params, int nopol);
 void dump_var_along(int i, int j, int nstep, struct of_traj *traj, int nx, int ny,
                     double scale, double cam[NDIM], double fovx, double fovy, Params *params);
 

--- a/src/model_geodesics.c
+++ b/src/model_geodesics.c
@@ -130,8 +130,8 @@ void init_XK(int i, int j, int nx, int ny, double Xcam[NDIM],
   // xoff: allow arbitrary offset for e.g. ML training imgs
   // +0.5: project geodesics from px centers
   // xoff/yoff are separated to keep consistent behavior between refinement levels
-  double dxoff = (i+0.5-0.01)/nx - 0.5 + params.xoff/params.nx;
-  double dyoff = (j+0.5)/ny - 0.5 + params.yoff/params.ny;
+  double dxoff = (i+0.5-0.01)/nx - 0.5 + params.xoff/nx;
+  double dyoff = (j+0.5)/ny - 0.5 + params.yoff/ny;
   Kcon_tetrad[0] = 0.;
   Kcon_tetrad[1] = (dxoff*cos(params.rotcam) - dyoff*sin(params.rotcam)) * fovx;
   Kcon_tetrad[2] = (dxoff*sin(params.rotcam) + dyoff*cos(params.rotcam)) * fovy;

--- a/tests/refinement/refinement.par
+++ b/tests/refinement/refinement.par
@@ -10,8 +10,8 @@ ny_min 20
 
 # Refine on either a relative or absolute
 # interpolation error
-refine_rel 1.e-1
-refine_abs 1.e-5
+refine_rel 1.e-2
+refine_abs 1.e-6
 
 # Only refine in 4-pixel groups with more than
 # this proportion of the average flux


### PR DESCRIPTION
This slightly modifies Zack's excellent adaptive res PR to support even numbers of pixels, by distinguishing between an "internal resolution" (always odd, for memory sizes and loops) called "nx/ny", and "output resolution" (even or odd), which determines FOV, geodesic positions, and file output.

This results in dropping the last row/col for even sizes, preserving the same geodesics/FOV as if they had never been computed in the first place.

With this, ipole should again be able to pass the "refinement" regression test, albeit with tighter criteria as the new algorithm is (rightly) more reluctant to trace pixels than my trigger-happy old version.

A couple style changes as well, where the formatter had sided with GNU over ipole precedent (gonna have to fix the format spec...)