### PR TITLE
Fix test script for Apple's Bash 3

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -9,7 +9,7 @@
 
 for folder in */
 do
-  folder=${folder: : -1}
+  folder=$(echo $folder | sed 's/.$//')
   if [[ "$folder" != "test-resources" ]]; then
     cd $folder
     if [[ $folder == *"sample_dump"* ]]; then


### PR DESCRIPTION
The "run_tests.sh" script previously didn't work on macs since it used newer Bash features.  This tries to be as compatible as possible by calling out to standard utilities.

Works everywhere for me but wanted to stage this in case it breaks something.