### PR TITLE
Fix some odd pixels

### DIFF
--- a/src/ipolarray.c
+++ b/src/ipolarray.c
@@ -453,20 +453,22 @@ int evolve_N(double Xi[NDIM], double Kconi[NDIM],
 
   *tauF += dlam*fabs(rV); //*sqrt(SQ*SQ + SU*SU);
 
-  // Correct the resulting Stokes parameters to guarantee:
-  // 1. I > 0
-  // 2. sqrt(Q^2 + U^2 + V^2) < I
-  if (SI < 0) {
-    SI = 0;
-    SQ = 0;
-    SU = 0;
-    SV = 0;
-  } else {
-    double pol_frac = sqrt(SQ*SQ + SU*SU + SV*SV) / SI;
-    if ( pol_frac > 1. ) {
-      SQ /= pol_frac;
-      SU /= pol_frac;
-      SV /= pol_frac;
+  if (params->stokes_floors) {
+    // Correct the resulting Stokes parameters to guarantee:
+    // 1. I > 0
+    // 2. sqrt(Q^2 + U^2 + V^2) < I
+    if (SI < 0) {
+      SI = 0;
+      SQ = 0;
+      SU = 0;
+      SV = 0;
+    } else {
+      double pol_frac = sqrt(SQ*SQ + SU*SU + SV*SV) / SI;
+      if ( pol_frac > 1. ) {
+        SQ /= pol_frac;
+        SU /= pol_frac;
+        SV /= pol_frac;
+      }
     }
   }
 

--- a/src/ipolarray.c
+++ b/src/ipolarray.c
@@ -405,6 +405,22 @@ int evolve_N(double Xi[NDIM], double Kconi[NDIM],
 
   *tauF += dlam*fabs(rV); //*sqrt(SQ*SQ + SU*SU);
 
+  if (SI < 0) {
+    SI = 0;
+    SQ = 0;
+    SU = 0;
+    SV = 0;
+  } else {
+    double overpol = sqrt(SQ*SQ + SU*SU + SV*SV) / SI;
+    if ( overpol > 1. ) {
+      printf("Stokes start: %g %g %g %g Middle: %g %g %g %g End: %g %g %g %g Final %g %g %g %g\n",
+              SI0, SQ0, SU0, SV0, SI1, SQ1, SU1, SV1, SI2, SQ2, SU2, SV2, SI, SQ, SU, SV);
+      SQ /= overpol;
+      SU /= overpol;
+      SV /= overpol;
+    }
+  }
+
   /* re-pack the Stokes parameters into N */
   stokes_to_tensor(SI, SQ, SU, SV, N_tetrad);
   complex_tetrad_to_coord_rank2(N_tetrad, Econ, N_coord);

--- a/src/ipolarray.c
+++ b/src/ipolarray.c
@@ -341,6 +341,15 @@ int evolve_N(double Xi[NDIM], double Kconi[NDIM],
         + adj / (aI2 - aP2) * (-1 + (aI * sinhaPx + aP * coshaPx) / aP * expaIx)
         + aI * jI / (aI2 - aP2) * (1 - (aI * coshaPx + aP * sinhaPx) / aI * expaIx));
 
+#if DEBUG
+    double term1 = fabs(SI1 * coshaPx * expaIx);
+    double term2 = fabs( - (ads0 / aP) * sinhaPx * expaIx);
+    double term3 = fabs( adj / (aI2 - aP2) * (-1 + (aI * sinhaPx + aP * coshaPx) / aP * expaIx) );
+    double term4 = fabs( aI * jI / (aI2 - aP2) * (1 - (aI * coshaPx + aP * sinhaPx) / aI * expaIx) );
+    if (fmax(fmax(fmax(term1, term2), term3), term4) / fabs(SI2) > 1e16)
+      printf("CAT I: Term1: %g 2: %g 3: %g 4: %g Total: %g\n", term1, term2, term3, term4, SI2);
+#endif
+
     SQ2 = (SQ1 * expaIx
         + ads0 * aQ / aP2 * (-1 + coshaPx) * expaIx
         - aQ / aP * SI1 * sinhaPx * expaIx
@@ -348,6 +357,19 @@ int evolve_N(double Xi[NDIM], double Kconi[NDIM],
         + adj * aQ / (aI * (aI2 - aP2)) * (1 - (1 - aI2 / aP2) * expaIx
             - aI / aP2 * (aI * coshaPx + aP * sinhaPx) * expaIx)
         + jI * aQ / (aP * (aI2 - aP2)) * (-aP + (aP * coshaPx + aI * sinhaPx) * expaIx));
+
+#if DEBUG
+    term1 = fabs( SQ1 * expaIx );
+    term2 = fabs( ads0 * aQ / aP2 * (-1 + coshaPx) * expaIx );
+    term3 = fabs( - aQ / aP * SI1 * sinhaPx * expaIx );
+    term4 = fabs( jQ * (1 - expaIx) / aI );
+    double term5 = fabs( adj * aQ / (aI * (aI2 - aP2)) * (1 - (1 - aI2 / aP2) * expaIx
+                                              - aI / aP2 * (aI * coshaPx + aP * sinhaPx) * expaIx) );
+    double term6 = fabs( jI * aQ / (aP * (aI2 - aP2)) * (-aP + (aP * coshaPx + aI * sinhaPx) * expaIx) );
+
+    if (fmax(fmax(fmax(fmax(fmax(term1, term2), term3), term4), term5), term6) / fabs(SQ2) > 1e16)
+      printf("CAT Q: Term1: %g 2: %g 3: %g 4: %g 5: %g 6: %g Total: %g\n", term1, term2, term3, term4, term5, term6, SQ2);
+#endif
 
     SU2 = (SU1 * expaIx
         + ads0 * aU / aP2 * (-1 + coshaPx) * expaIx
@@ -360,6 +382,19 @@ int evolve_N(double Xi[NDIM], double Kconi[NDIM],
         + jI * aU / (aP * (aI2 - aP2)) *
         (-aP + (aP * coshaPx + aI * sinhaPx) * expaIx));
 
+#if DEBUG
+    term1 = fabs( SU1 * expaIx );
+    term2 = fabs( ads0 * aU / aP2 * (-1 + coshaPx) * expaIx );
+    term3 = fabs( - aU / aP * SI1 * sinhaPx * expaIx );
+    term4 = fabs( jU * (1 - expaIx) / aI );
+    term5 = fabs( adj * aU / (aI * (aI2 - aP2)) * (1 - (1 - aI2 / aP2) * expaIx -
+                                                  aI / aP2 * (aI * coshaPx + aP * sinhaPx) * expaIx) );
+    term6 = fabs( jI * aU / (aP * (aI2 - aP2)) * (-aP + (aP * coshaPx + aI * sinhaPx) * expaIx) );
+
+    if (fmax(fmax(fmax(fmax(fmax(term1, term2), term3), term4), term5), term6) / fabs(SU2) > 1e16)
+      printf("CAT U: Term1: %g 2: %g 3: %g 4: %g 5: %g 6: %g Total: %g\n", term1, term2, term3, term4, term5, term6, SU2);
+#endif
+
     SV2 = (SV1 * expaIx
         + ads0 * aV / aP2 * (-1 + coshaPx) * expaIx
         - aV / aP * SI1 * sinhaPx * expaIx
@@ -370,6 +405,19 @@ int evolve_N(double Xi[NDIM], double Kconi[NDIM],
                 aP * sinhaPx) * expaIx)
         + jI * aV / (aP * (aI2 - aP2)) *
         (-aP + (aP * coshaPx + aI * sinhaPx) * expaIx));
+
+#if DEBUG
+    term1 = fabs( SV1 * expaIx );
+    term2 = fabs( ads0 * aV / aP2 * (-1 + coshaPx) * expaIx );
+    term3 = fabs( - aV / aP * SI1 * sinhaPx * expaIx );
+    term4 = fabs( jV * (1 - expaIx) / aI );
+    term5 = fabs( adj * aV / (aI * (aI2 - aP2)) * (1 - (1 - aI2 / aP2) * expaIx -
+                                                    aI / aP2 * (aI * coshaPx + aP * sinhaPx) * expaIx) );
+    term6 = fabs( jI * aV / (aP * (aI2 - aP2)) * (-aP + (aP * coshaPx + aI * sinhaPx) * expaIx) );
+
+    if (fmax(fmax(fmax(fmax(fmax(term1, term2), term3), term4), term5), term6) / fabs(SV2) > 1e16)
+      printf("CAT V: Term1: %g 2: %g 3: %g 4: %g 5: %g 6: %g Total: %g\n", term1, term2, term3, term4, term5, term6, SV2);
+#endif
 
   } else {
     // Still account for aI which may be >> aP, e.g. simulating unpolarized transport
@@ -405,19 +453,20 @@ int evolve_N(double Xi[NDIM], double Kconi[NDIM],
 
   *tauF += dlam*fabs(rV); //*sqrt(SQ*SQ + SU*SU);
 
+  // Correct the resulting Stokes parameters to guarantee:
+  // 1. I > 0
+  // 2. sqrt(Q^2 + U^2 + V^2) < I
   if (SI < 0) {
     SI = 0;
     SQ = 0;
     SU = 0;
     SV = 0;
   } else {
-    double overpol = sqrt(SQ*SQ + SU*SU + SV*SV) / SI;
-    if ( overpol > 1. ) {
-      printf("Stokes start: %g %g %g %g Middle: %g %g %g %g End: %g %g %g %g Final %g %g %g %g\n",
-              SI0, SQ0, SU0, SV0, SI1, SQ1, SU1, SV1, SI2, SQ2, SU2, SV2, SI, SQ, SU, SV);
-      SQ /= overpol;
-      SU /= overpol;
-      SV /= overpol;
+    double pol_frac = sqrt(SQ*SQ + SU*SU + SV*SV) / SI;
+    if ( pol_frac > 1. ) {
+      SQ /= pol_frac;
+      SU /= pol_frac;
+      SV /= pol_frac;
     }
   }
 

--- a/src/par.c
+++ b/src/par.c
@@ -51,7 +51,7 @@ void load_par_from_argv(int argc, char *argv[], Params *params) {
   params->old_centering = 0;
 
   params->emission_type = 4;
-  params->stokes_floors = 1;
+  params->stokes_floors = 0;
 
   params->isolate_counterjet = 0;
 

--- a/src/par.c
+++ b/src/par.c
@@ -51,6 +51,7 @@ void load_par_from_argv(int argc, char *argv[], Params *params) {
   params->old_centering = 0;
 
   params->emission_type = 4;
+  params->stokes_floors = 1;
 
   params->isolate_counterjet = 0;
 
@@ -130,6 +131,7 @@ void try_set_parameter(const char *word, const char *value, Params *params) {
   set_by_word_val(word, value, "quench_output", &(params->quench_output), TYPE_INT);
   set_by_word_val(word, value, "only_unpolarized", &(params->only_unpolarized), TYPE_INT);
   set_by_word_val(word, value, "emission_type", &(params->emission_type), TYPE_INT);
+  set_by_word_val(word, value, "stokes_floors", &(params->stokes_floors), TYPE_INT);
   set_by_word_val(word, value, "counterjet", &(params->isolate_counterjet), TYPE_INT);
   set_by_word_val(word, value, "old_centering", &(params->old_centering), TYPE_INT);
 

--- a/src/par.h
+++ b/src/par.h
@@ -31,6 +31,9 @@ typedef struct params_t {
 
   // Which e- energy distributions/emissivities to use
   int emission_type;
+  // Whether to apply I > 0 "floor" when integrating forward the Stokes parameters
+  // Probably harmless!
+  int stokes_floors;
 
   int isolate_counterjet;
 


### PR DESCRIPTION
In areas of very low emissivity but high absorptivity, even the analytic solution to the transport equation becomes numerically unstable due to catastrophic cancellation.

This can cause two undesired effects:
1. sqrt(Q^2 + U^2 + V^2) >> I
2. I < 0

These effects are usually not a problem, as they occur only for pixels with very small total emission.  However, when exacerbated by numerically difficult tetrad choices, they can fail to cancel and produce low total emission, resulting in significantly negative or NaN-valued intensity in a few unlucky pixels.

This branch enforces that neither (1) nor (2) are true of the results of a fluid-frame step when solving the transport equation.

Ideally, the proper solution here is to avoid the vast scale separations which cause these catastrophic cancellations in the first place...