### PR TITLE
Fix tetrad creation

### DIFF
--- a/model/iharm/model.c
+++ b/model/iharm/model.c
@@ -336,7 +336,7 @@ void get_model_fourv(double X[NDIM], double Kcon[NDIM],
   // Bcon/Bcov to zero.
   if ( X_in_domain(X) == 0 ) {
 
-    Ucov[0] = -1./sqrt(-gcov[0][0]);
+    Ucov[0] = -1./sqrt(-gcon[0][0]);
     Ucov[1] = 0.;
     Ucov[2] = 0.;
     Ucov[3] = 0.;
@@ -353,7 +353,7 @@ void get_model_fourv(double X[NDIM], double Kcon[NDIM],
       Bcon[mu] = 0.;
       Bcov[mu] = 0.;
     }
-   
+
     return;
   }
 

--- a/src/ipolarray.c
+++ b/src/ipolarray.c
@@ -609,11 +609,6 @@ void complex_lower(double complex N[NDIM][NDIM],
 void stokes_to_tensor(double fI, double fQ, double fU, double fV,
     double complex f_tetrad[NDIM][NDIM])
 {
-  int i, j;
-
-  for (i = 0; i < 4; i++)
-  for (j = 0; j < 4; j++)
-  f_tetrad[i][j] = 0. + I * 0.;
   /*notice that I swapped sign of the imaginary part [2][3] in [3][2] - which one is correct? */
   f_tetrad[1][1] = (fI + fQ + 0. * I);
   f_tetrad[1][2] = (fU - I * fV);

--- a/src/ipolarray.c
+++ b/src/ipolarray.c
@@ -19,6 +19,11 @@
 #include "debug_tools.h"
 #include <complex.h>
 
+// These are related mostly to where exp() and 1/x overflow
+// desired accuracy.
+#define CUT_HIGH_ABS 500
+#define CUT_LOW_ABS SMALL
+
 // Sub-functions
 void push_polar(double Xi[NDIM], double Xm[NDIM], double Xf[NDIM],
     double Ki[NDIM], double Km[NDIM], double Kf[NDIM],
@@ -349,7 +354,7 @@ int evolve_N(double Xi[NDIM], double Kconi[NDIM],
   double ads0 = aQ * SQ1 + aU * SU1 + aV * SV1;
   double adj = aQ * jQ + aU * jU + aV * jV;
 
-  if (aP*x > 500 || aI*x > 500) {
+  if (aP*x > CUT_HIGH_ABS || aI*x > CUT_HIGH_ABS) {
     // Solution assuming aI ~ aP >> 1, the worst case.
     // This covers the case aI >> aP by sending exp(aP-aI)->0, which is safe for all terms
     double expDiffx = exp((aP-aI) * x)/2;
@@ -380,7 +385,7 @@ int evolve_N(double Xi[NDIM], double Kconi[NDIM],
             aI / aP2 * (aI * expDiffx + aP * expDiffx))
         + jI * aV / (aP * (aI2 - aP2)) *
         (-aP + (aP * expDiffx + aI * expDiffx)));
-  } else if (aP*x > SMALL) { /* full analytic solution has trouble if polarized absorptivity is small */
+  } else if (aP*x > CUT_LOW_ABS) { /* full analytic solution has trouble if polarized absorptivity is small */
     double expaIx = exp(-aI * x);
     double sinhaPx = sinh(aP * x);
     double coshaPx = cosh(aP * x);

--- a/src/ipolarray.c
+++ b/src/ipolarray.c
@@ -349,7 +349,38 @@ int evolve_N(double Xi[NDIM], double Kconi[NDIM],
   double ads0 = aQ * SQ1 + aU * SU1 + aV * SV1;
   double adj = aQ * jQ + aU * jU + aV * jV;
 
-  if (aP > SMALL) { /* full analytic solution has trouble if polarized absorptivity is small */
+  if (aP > 500 || aI > 500) {
+    // Solution assuming aI ~ aP >> 1, the worst case.
+    // This covers the case aI >> aP by sending exp(aP-aI)->0, which is safe for all terms
+    double expDiffx = exp((aP-aI) * x)/2;
+
+    SI2 = (SI1 * expDiffx
+        - (ads0 / aP) * expDiffx
+        + adj / (aI2 - aP2) * (-1 + (aI * expDiffx + aP * expDiffx) / aP)
+        + aI * jI / (aI2 - aP2) * (1 - (aI * expDiffx + aP * expDiffx) / aI));
+
+    SQ2 = (ads0 * aQ / aP2 * expDiffx
+        - aQ / aP * SI1 * expDiffx
+        + jQ / aI
+        + adj * aQ / (aI * (aI2 - aP2)) *
+        (1 - aI / aP2 * (aI * expDiffx + aP * expDiffx))
+        + jI * aQ / (aP * (aI2 - aP2)) * (-aP + (aP * expDiffx + aI * expDiffx)));
+
+    SU2 = (ads0 * aU / aP2 * expDiffx
+        - aU / aP * SI1 * expDiffx
+        + jU / aI
+        + adj * aU / (aI * (aI2 - aP2)) *
+        (1 - aI / aP2 * (aI * expDiffx + aP * expDiffx))
+        + jI * aU / (aP * (aI2 - aP2)) * (-aP + (aP * expDiffx + aI * expDiffx)));
+
+    SV2 = (ads0 * aV / aP2 * expDiffx
+        - aV / aP * SI1 * expDiffx
+        + jV / aI
+        + adj * aV / (aI * (aI2 - aP2)) * (1 -
+            aI / aP2 * (aI * expDiffx + aP * expDiffx))
+        + jI * aV / (aP * (aI2 - aP2)) *
+        (-aP + (aP * expDiffx + aI * expDiffx)));
+  } else if (aP > SMALL) { /* full analytic solution has trouble if polarized absorptivity is small */
     double expaIx = exp(-aI * x);
     double sinhaPx = sinh(aP * x);
     double coshaPx = cosh(aP * x);
@@ -359,15 +390,6 @@ int evolve_N(double Xi[NDIM], double Kconi[NDIM],
         + adj / (aI2 - aP2) * (-1 + (aI * sinhaPx + aP * coshaPx) / aP * expaIx)
         + aI * jI / (aI2 - aP2) * (1 - (aI * coshaPx + aP * sinhaPx) / aI * expaIx));
 
-#if DEBUG
-    double term1 = fabs(SI1 * coshaPx * expaIx);
-    double term2 = fabs( - (ads0 / aP) * sinhaPx * expaIx);
-    double term3 = fabs( adj / (aI2 - aP2) * (-1 + (aI * sinhaPx + aP * coshaPx) / aP * expaIx) );
-    double term4 = fabs( aI * jI / (aI2 - aP2) * (1 - (aI * coshaPx + aP * sinhaPx) / aI * expaIx) );
-    if (fmax(fmax(fmax(term1, term2), term3), term4) / fabs(SI2) > 1e16)
-      printf("CAT I: Term1: %g 2: %g 3: %g 4: %g Total: %g\n", term1, term2, term3, term4, SI2);
-#endif
-
     SQ2 = (SQ1 * expaIx
         + ads0 * aQ / aP2 * (-1 + coshaPx) * expaIx
         - aQ / aP * SI1 * sinhaPx * expaIx
@@ -375,19 +397,6 @@ int evolve_N(double Xi[NDIM], double Kconi[NDIM],
         + adj * aQ / (aI * (aI2 - aP2)) * (1 - (1 - aI2 / aP2) * expaIx
             - aI / aP2 * (aI * coshaPx + aP * sinhaPx) * expaIx)
         + jI * aQ / (aP * (aI2 - aP2)) * (-aP + (aP * coshaPx + aI * sinhaPx) * expaIx));
-
-#if DEBUG
-    term1 = fabs( SQ1 * expaIx );
-    term2 = fabs( ads0 * aQ / aP2 * (-1 + coshaPx) * expaIx );
-    term3 = fabs( - aQ / aP * SI1 * sinhaPx * expaIx );
-    term4 = fabs( jQ * (1 - expaIx) / aI );
-    double term5 = fabs( adj * aQ / (aI * (aI2 - aP2)) * (1 - (1 - aI2 / aP2) * expaIx
-                                              - aI / aP2 * (aI * coshaPx + aP * sinhaPx) * expaIx) );
-    double term6 = fabs( jI * aQ / (aP * (aI2 - aP2)) * (-aP + (aP * coshaPx + aI * sinhaPx) * expaIx) );
-
-    if (fmax(fmax(fmax(fmax(fmax(term1, term2), term3), term4), term5), term6) / fabs(SQ2) > 1e16)
-      printf("CAT Q: Term1: %g 2: %g 3: %g 4: %g 5: %g 6: %g Total: %g\n", term1, term2, term3, term4, term5, term6, SQ2);
-#endif
 
     SU2 = (SU1 * expaIx
         + ads0 * aU / aP2 * (-1 + coshaPx) * expaIx
@@ -399,19 +408,6 @@ int evolve_N(double Xi[NDIM], double Kconi[NDIM],
                 aP * sinhaPx) * expaIx)
         + jI * aU / (aP * (aI2 - aP2)) *
         (-aP + (aP * coshaPx + aI * sinhaPx) * expaIx));
-
-#if DEBUG
-    term1 = fabs( SU1 * expaIx );
-    term2 = fabs( ads0 * aU / aP2 * (-1 + coshaPx) * expaIx );
-    term3 = fabs( - aU / aP * SI1 * sinhaPx * expaIx );
-    term4 = fabs( jU * (1 - expaIx) / aI );
-    term5 = fabs( adj * aU / (aI * (aI2 - aP2)) * (1 - (1 - aI2 / aP2) * expaIx -
-                                                  aI / aP2 * (aI * coshaPx + aP * sinhaPx) * expaIx) );
-    term6 = fabs( jI * aU / (aP * (aI2 - aP2)) * (-aP + (aP * coshaPx + aI * sinhaPx) * expaIx) );
-
-    if (fmax(fmax(fmax(fmax(fmax(term1, term2), term3), term4), term5), term6) / fabs(SU2) > 1e16)
-      printf("CAT U: Term1: %g 2: %g 3: %g 4: %g 5: %g 6: %g Total: %g\n", term1, term2, term3, term4, term5, term6, SU2);
-#endif
 
     SV2 = (SV1 * expaIx
         + ads0 * aV / aP2 * (-1 + coshaPx) * expaIx

--- a/src/ipolarray.c
+++ b/src/ipolarray.c
@@ -349,7 +349,7 @@ int evolve_N(double Xi[NDIM], double Kconi[NDIM],
   double ads0 = aQ * SQ1 + aU * SU1 + aV * SV1;
   double adj = aQ * jQ + aU * jU + aV * jV;
 
-  if (aP > 500 || aI > 500) {
+  if (aP*x > 500 || aI*x > 500) {
     // Solution assuming aI ~ aP >> 1, the worst case.
     // This covers the case aI >> aP by sending exp(aP-aI)->0, which is safe for all terms
     double expDiffx = exp((aP-aI) * x)/2;
@@ -380,7 +380,7 @@ int evolve_N(double Xi[NDIM], double Kconi[NDIM],
             aI / aP2 * (aI * expDiffx + aP * expDiffx))
         + jI * aV / (aP * (aI2 - aP2)) *
         (-aP + (aP * expDiffx + aI * expDiffx)));
-  } else if (aP > SMALL) { /* full analytic solution has trouble if polarized absorptivity is small */
+  } else if (aP*x > SMALL) { /* full analytic solution has trouble if polarized absorptivity is small */
     double expaIx = exp(-aI * x);
     double sinhaPx = sinh(aP * x);
     double coshaPx = cosh(aP * x);
@@ -419,19 +419,6 @@ int evolve_N(double Xi[NDIM], double Kconi[NDIM],
                 aP * sinhaPx) * expaIx)
         + jI * aV / (aP * (aI2 - aP2)) *
         (-aP + (aP * coshaPx + aI * sinhaPx) * expaIx));
-
-#if DEBUG
-    term1 = fabs( SV1 * expaIx );
-    term2 = fabs( ads0 * aV / aP2 * (-1 + coshaPx) * expaIx );
-    term3 = fabs( - aV / aP * SI1 * sinhaPx * expaIx );
-    term4 = fabs( jV * (1 - expaIx) / aI );
-    term5 = fabs( adj * aV / (aI * (aI2 - aP2)) * (1 - (1 - aI2 / aP2) * expaIx -
-                                                    aI / aP2 * (aI * coshaPx + aP * sinhaPx) * expaIx) );
-    term6 = fabs( jI * aV / (aP * (aI2 - aP2)) * (-aP + (aP * coshaPx + aI * sinhaPx) * expaIx) );
-
-    if (fmax(fmax(fmax(fmax(fmax(term1, term2), term3), term4), term5), term6) / fabs(SV2) > 1e16)
-      printf("CAT V: Term1: %g 2: %g 3: %g 4: %g 5: %g 6: %g Total: %g\n", term1, term2, term3, term4, term5, term6, SV2);
-#endif
 
   } else {
     // Still account for aI which may be >> aP, e.g. simulating unpolarized transport

--- a/src/model_tetrads.c
+++ b/src/model_tetrads.c
@@ -36,37 +36,32 @@ int make_plasma_tetrad(double Ucon[NDIM], double Kcon[NDIM], double Bcon[NDIM],
                         double Gcov[NDIM][NDIM], double Econ[NDIM][NDIM],
                         double Ecov[NDIM][NDIM])
 {
-  // start w/ time component parallel to U
+  // Modified Gram-Schmidt to produce e^n orthogonal
   set_Econ_from_trial(Econ[0], 0, Ucon);
   normalize(Econ[0], Gcov);
-
-  /*** done w/ basis vector 0 ***/
-
-  /* now use the trial vector in basis vector 3 */
-  /* cast a suspicious eye on the trial vector... */
-
   set_Econ_from_trial(Econ[3], 3, Kcon);
-
-  /* project out econ0 */
   project_out(Econ[3], Econ[0], Gcov);
   normalize(Econ[3], Gcov);
-
-  /*** done w/ basis vector 3 ***/
-
-  // repeat for x2 unit basis vector
   set_Econ_from_trial(Econ[2], 2, Bcon);
-
-  // project out econ0,3
   project_out(Econ[2], Econ[0], Gcov);
   project_out(Econ[2], Econ[3], Gcov);
   normalize(Econ[2], Gcov);
-
-  /*** done w/ basis vector 2 ***/
-
   // whatever is left is econ1
   for (int k = 0; k < 4; k++) /* trial vector */
     Econ[1][k] = 1.;
-  // project out econ[0-2]
+  project_out(Econ[1], Econ[0], Gcov);
+  project_out(Econ[1], Econ[2], Gcov);
+  project_out(Econ[1], Econ[3], Gcov);
+  normalize(Econ[1], Gcov);
+
+  // Reorthogonalize.  I swear this is a real thing
+  // TODO may not require renormalization
+  normalize(Econ[0], Gcov);
+  project_out(Econ[3], Econ[0], Gcov);
+  normalize(Econ[3], Gcov);
+  project_out(Econ[2], Econ[0], Gcov);
+  project_out(Econ[2], Econ[3], Gcov);
+  normalize(Econ[2], Gcov);
   project_out(Econ[1], Econ[0], Gcov);
   project_out(Econ[1], Econ[2], Gcov);
   project_out(Econ[1], Econ[3], Gcov);


### PR DESCRIPTION
This commit applies reorthogonalization to the Gram-Schmidt method used by ipole to orthonormalize tetrads.  This potentially costs accuracy to the original vectors but ensures the resulting tetrads are, well, orthonormal, to machine precision.

It avoids assuming that in the fluid frame, the first & last row & column of N (N_tetrad) will be zero -- instead just modifying those elements affected by Stokes transport in the fluid frame.  This hugely improves accuracy in areas of low emission with difficult-to-make tetrads.

Finally, it adds a high-absorptivity limiting expression to the analytic solutions ipole uses to advance the Stokes parameters in fluid frame.  Certain areas of some dumps were producing absorptivities so high that exp(aP*dlam) was overflowing double precision, producing NaN results.

The most important/concerning piece of this PR is that it chooses creating a consistent orthonormal frame above lining up that frame's vectors with u, K, b.  If much emission occurs in any of the areas these fixes are applicable, it has the potential to be inaccurate