### PR TITLE
feature/check

### DIFF
--- a/model/iharm/example.par
+++ b/model/iharm/example.par
@@ -1,7 +1,7 @@
 # example.par -- ipole example parameter file for iharm problem
 
 # Common
-dump /home/bprather/Analysis/samples/iharm3d/SANE_a+0.94_288_0900_MKS.h5
+dump tests/test-resources/sample_dump_SANE_a+0.94_MKS_0900.h5
 outfile image.h5
 nx 160
 ny 160

--- a/model/iharm/model.c
+++ b/model/iharm/model.c
@@ -277,7 +277,7 @@ void init_model(double *tA, double *tB)
   update_data(tA, tB);
   tf = get_dump_t(fnam, dumpmax) - 1.e-5;
   #else // FAST LIGHT
-  data[2]->t =10000.;
+  data[2]->t = 10000.;
   #endif // SLOW_LIGHT
 
   // horizon radius
@@ -360,19 +360,12 @@ void get_model_fourv(double X[NDIM], double Kcon[NDIM],
   // Set Ucon and get Ucov by lowering
 
   // interpolate primitive variables first
-  double U1A, U2A, U3A, U1B, U2B, U3B, tfac;
   double Vcon[NDIM];
   int nA, nB;
-  tfac = set_tinterp_ns(X, &nA, &nB);
-  U1A = interp_scalar(X, data[nA]->p[U1]);
-  U2A = interp_scalar(X, data[nA]->p[U2]);
-  U3A = interp_scalar(X, data[nA]->p[U3]);
-  U1B = interp_scalar(X, data[nB]->p[U1]);
-  U2B = interp_scalar(X, data[nB]->p[U2]);
-  U3B = interp_scalar(X, data[nB]->p[U3]);
-  Vcon[1] = tfac*U1A + (1. - tfac)*U1B;
-  Vcon[2] = tfac*U2A + (1. - tfac)*U2B;
-  Vcon[3] = tfac*U3A + (1. - tfac)*U3B;
+  double tfac = set_tinterp_ns(X, &nA, &nB);
+  Vcon[1] = interp_scalar_time(X, data[nA]->p[U1], data[nB]->p[U1], tfac);
+  Vcon[2] = interp_scalar_time(X, data[nA]->p[U2], data[nB]->p[U2], tfac);
+  Vcon[3] = interp_scalar_time(X, data[nA]->p[U3], data[nB]->p[U3], tfac);
 
   // translate to four velocity
   double VdotV = 0.;
@@ -390,17 +383,9 @@ void get_model_fourv(double X[NDIM], double Kcon[NDIM],
   // Now set Bcon and get Bcov by lowering
 
   // interpolate primitive variables first
-  double B1A, B2A, B3A, B1B, B2B, B3B, Bcon1, Bcon2, Bcon3;
-  tfac = set_tinterp_ns(X, &nA, &nB);
-  B1A = interp_scalar(X, data[nA]->p[B1]);
-  B2A = interp_scalar(X, data[nA]->p[B2]);
-  B3A = interp_scalar(X, data[nA]->p[B3]);
-  B1B = interp_scalar(X, data[nB]->p[B1]);
-  B2B = interp_scalar(X, data[nB]->p[B2]);
-  B3B = interp_scalar(X, data[nB]->p[B3]);
-  Bcon1 = tfac*B1A + (1. - tfac)*B1B;
-  Bcon2 = tfac*B2A + (1. - tfac)*B2B;
-  Bcon3 = tfac*B3A + (1. - tfac)*B3B;
+  double Bcon1 = interp_scalar_time(X, data[nA]->p[B1], data[nB]->p[B1], tfac);
+  double Bcon2 = interp_scalar_time(X, data[nA]->p[B2], data[nB]->p[B2], tfac);
+  double Bcon3 = interp_scalar_time(X, data[nA]->p[B3], data[nB]->p[B3], tfac);
 
   // get Bcon
   Bcon[0] = Bcon1*Ucov[1] + Bcon2*Ucov[2] + Bcon3*Ucov[3];
@@ -419,14 +404,11 @@ void get_model_primitives(double X[NDIM], double *p)
 {
   if ( X_in_domain(X) == 0 ) return;
 
-  double bA, bB, tfac;
   int nA, nB;
-  tfac = set_tinterp_ns(X, &nA, &nB);
+  double tfac = set_tinterp_ns(X, &nA, &nB);
 
   for (int np=0; np<8; np++) {
-    bA = interp_scalar(X, data[nA]->p[np]);
-    bB = interp_scalar(X, data[nB]->p[np]);
-    p[np] = tfac*bA + (1. - tfac)*bB;
+    p[np] = interp_scalar_time(X, data[nA]->p[np], data[nA]->p[np], tfac);
   }
 }
 
@@ -434,24 +416,18 @@ double get_model_thetae(double X[NDIM])
 {
   if ( X_in_domain(X) == 0 ) return 0.;
   
-  double thetaeA, thetaeB, tfac;
   int nA, nB;
-  tfac = set_tinterp_ns(X, &nA, &nB);
-  thetaeA = interp_scalar(X, data[nA]->thetae);
-  thetaeB = interp_scalar(X, data[nB]->thetae);
+  double tfac = set_tinterp_ns(X, &nA, &nB);
+  double thetae = interp_scalar_time(X, data[nA]->thetae, data[nB]->thetae, tfac);
 
-  double thetae = tfac*thetaeA + (1. - tfac)*thetaeB;
   if (thetae < 0.) {
     printf("thetae negative!\n");
     printf("X[] = %g %g %g %g\n", X[0], X[1], X[2], X[3]);
     printf("t = %e %e %e\n", data[0]->t, data[1]->t, data[2]->t);
-    printf("thetae = %e tfac = %e thetaeA = %e thetaeB = %e nA = %i nB = %i\n",
-    thetae, tfac, thetaeA, thetaeB, nA, nB);
+    printf("thetae = %e\n", thetae);
   }
 
-  if (thetaeA < 0 || thetaeB < 0) fprintf(stderr, "TETE %g %g\n", thetaeA, thetaeB);
-
-  return tfac*thetaeA + (1. - tfac)*thetaeB;
+  return thetae;
 }
 
 //b field strength in Gauss
@@ -460,25 +436,20 @@ double get_model_b(double X[NDIM])
   // TODO how *should* we handle exiting the domain consistently?
   if ( X_in_domain(X) == 0 ) return 0.;
   
-  double bA, bB, tfac;
   int nA, nB;
-  tfac = set_tinterp_ns(X, &nA, &nB);
-  bA = interp_scalar(X, data[nA]->b);
-  bB = interp_scalar(X, data[nB]->b);
+  double tfac = set_tinterp_ns(X, &nA, &nB);
 
-  return tfac*bA + (1. - tfac)*bB;
+  return interp_scalar_time(X, data[nA]->b, data[nB]->b, tfac);
 }
 
 double get_model_sigma(double X[NDIM]) 
 {
   if ( X_in_domain(X) == 0 ) return 0.;
 
-  double sigmaA, sigmaB, tfac;
   int nA, nB;
-  tfac = set_tinterp_ns(X, &nA, &nB);
-  sigmaA = interp_scalar(X, data[nA]->sigma);
-  sigmaB = interp_scalar(X, data[nB]->sigma);
-  return tfac*sigmaA + (1. - tfac)*sigmaB;
+  double tfac = set_tinterp_ns(X, &nA, &nB);
+
+  return interp_scalar_time(X, data[nA]->sigma, data[nB]->sigma, tfac);
 }
 
 double get_model_ne(double X[NDIM])
@@ -490,12 +461,10 @@ double get_model_ne(double X[NDIM])
   if (sigma > sigma_cut) return 0.;
 #endif
 
-  double neA, neB, tfac;
   int nA, nB;
-  tfac = set_tinterp_ns(X, &nA, &nB);
-  neA = interp_scalar(X, data[nA]->ne);
-  neB = interp_scalar(X, data[nB]->ne);
-  return tfac*neA + (1. - tfac)*neB;
+  double tfac = set_tinterp_ns(X, &nA, &nB);
+
+  return interp_scalar_time(X, data[nA]->ne, data[nB]->ne, tfac);
 }
 
 void set_units()

--- a/model/iharm/model.c
+++ b/model/iharm/model.c
@@ -1033,7 +1033,7 @@ void load_hamr_data(int n, char *fnam, int dumpidx, int verbose)
   hsize_t fstart[] = { 0 };
   hsize_t fcount[] = { N1 * N2 * N3 };
 
-  double *buffer = malloc(N1*N2*N3 * sizeof(*buffer));
+  double *buffer = calloc(N1*N2*N3, sizeof(*buffer));
 
   hdf5_read_array(buffer, "RHO", 1, fdims, fstart, fcount, fdims, fstart, H5T_IEEE_F64LE);
   remap_hamr(buffer, data[n]->p[KRHO], N1, N2, N3, 1);

--- a/src/decs.h
+++ b/src/decs.h
@@ -8,7 +8,7 @@
 #include <stdio.h>
 
 // Strings and string tools
-#define VERSION_STRING "ipole-release-1.3"
+#define VERSION_STRING "ipole-release-1.4"
 #define xstr(s) str(s)
 #define str(s) #s
 #define STRLEN (2048)

--- a/src/grid.c
+++ b/src/grid.c
@@ -13,8 +13,8 @@ int N1, N2, N3;
 /* return scalar in cgs units */
 double interp_scalar(double X[NDIM], double ***var)
 {
-  double del[NDIM],b1,b2,interp;
-  int i, j, k, ip1, jp1, kp1;
+  double del[NDIM] = {0}, b1 = 0, b2 = 0, interp = 0;
+  int i = 0, j = 0, k = 0, ip1 = 0, jp1 = 0, kp1 = 0;
 
   // zone and offset from X
   Xtoijk(X, &i, &j, &k, del);
@@ -111,8 +111,8 @@ void ijktoX(int i, int j, int k, double X[NDIM])
 void Xtoijk(double X[NDIM], int *i, int *j, int *k, double del[NDIM])
 {
   // unless we're reading from data, i,j,k are the normal expected thing
-  double phi;
-  double XG[4];
+  double phi = 0;
+  double XG[4] = {0};
 
   if (use_eKS_internal) {
     // the geodesics are evolved in eKS so invert through KS -> zone coordinates

--- a/src/grid.c
+++ b/src/grid.c
@@ -47,6 +47,15 @@ double interp_scalar(double X[NDIM], double ***var)
   return interp;
 }
 
+/* return scalar interpolated in time */
+double interp_scalar_time(double X[NDIM], double ***varA, double ***varB, double tfac)
+{
+  double vA = interp_scalar(X, varA);
+  double vB = interp_scalar(X, varB);
+
+  return tfac*vA + (1. - tfac)*vB;
+}
+
 /*
  *  returns geodesic coordinates associated with center of zone i,j,k
  */

--- a/src/grid.c
+++ b/src/grid.c
@@ -51,9 +51,13 @@ double interp_scalar(double X[NDIM], double ***var)
 double interp_scalar_time(double X[NDIM], double ***varA, double ***varB, double tfac)
 {
   double vA = interp_scalar(X, varA);
-  double vB = interp_scalar(X, varB);
 
+#if SLOWLIGHT
+  double vB = interp_scalar(X, varB);
   return tfac*vA + (1. - tfac)*vB;
+#endif
+
+  return vA;
 }
 
 /*

--- a/src/grid.h
+++ b/src/grid.h
@@ -13,5 +13,6 @@ void Xtoijk(double X[NDIM], int *i, int *j, int *k, double del[NDIM]);
 int X_in_domain(double X[NDIM]);
 
 double interp_scalar(double X[NDIM], double ***var);
+double interp_scalar_time(double X[NDIM], double ***varA, double ***varB, double tfac);
 
 #endif // GRID_H

--- a/src/io.c
+++ b/src/io.c
@@ -34,8 +34,8 @@ void read_restart(const char *fname, double *tA, double *tB, double *last_img_ta
   hdf5_read_single_val(nimg, "nimg", H5T_STD_I32LE);
   hdf5_read_single_val(nopenimgs, "nopenimgs", H5T_STD_I32LE);
 
-  int *tint = malloc(s2 * sizeof(*tint));
-  double *tdbl = malloc(s2 * sizeof(*tdbl));
+  int *tint = calloc(s2, sizeof(*tint));
+  double *tdbl = calloc(s2, sizeof(*tdbl));
 
   for (int i=0; i<nconcurrentimgs; ++i) {
     tdbl[i] = target_times[i];
@@ -101,8 +101,8 @@ void write_restart(const char *fname, double tA, double tB, double last_img_targ
   hdf5_make_directory("dimg");
   hdf5_set_directory("/dimg/");
   // save dimg struct
-  int *tint = malloc(s2 * sizeof(*tint));
-  double *tdbl = malloc(s2 * sizeof(*tdbl));
+  int *tint = calloc(s2, sizeof(*tint));
+  double *tdbl = calloc(s2, sizeof(*tdbl));
 
   for (int i=0; i<s2; ++i) tint[i] = dimages[i].nstep;
   hdf5_write_full_array(tint, "nstep", 1, dims, H5T_STD_I32LE);

--- a/src/io.c
+++ b/src/io.c
@@ -186,10 +186,48 @@ void write_header(double scale, double cam[NDIM],
   output_hdf5();
 }
 
+void dump_check(double image[], double imageS[], double taus[], Params *params, int skip)
+{
+  int unpol = params->only_unpolarized;
+
+  size_t nx = params->nx;
+  size_t ny = params->ny;
+
+  if (access(params->outf, F_OK) != -1) {
+    hdf5_append(params->outf);
+  } else {
+    fprintf(stderr, "oh no :(\nno file to check.\n\n");
+    return;
+  }
+
+  hsize_t unpol_mdim[2] = {nx, ny};
+  hsize_t pol_mdim[3] = {nx, ny, NIMG};
+  hsize_t unpol_fdim[2] = { (int)ceil(nx/skip), (int)ceil(ny/skip) };
+  hsize_t pol_fdim[3] = { (int)ceil(nx/skip), (int)ceil(ny/skip), NIMG };
+  hsize_t unpol_start[2] = {0, 0};
+  hsize_t pol_start[3] = {0, 0, 0};
+
+  hdf5_write_array(image, "unpol_check", 2, unpol_fdim, unpol_start, unpol_fdim, unpol_mdim, unpol_start, H5T_IEEE_F64LE);
+  hdf5_write_array(taus, "tau_check", 2, unpol_fdim, unpol_start, unpol_fdim, unpol_mdim, unpol_start, H5T_IEEE_F64LE);
+  if (!unpol) hdf5_write_array(imageS, "pol_check", 3, pol_fdim, pol_start, pol_fdim, pol_mdim, pol_start, H5T_IEEE_F64LE);
+
+  hsize_t unpol_mstart[2] = { (int)ceil(nx/skip), 0 };
+  hsize_t pol_mstart[3] = { unpol_mstart[0], 0, 0 };
+
+  hdf5_write_array(image, "unpol_recheck", 2, unpol_fdim, unpol_start, unpol_fdim, unpol_mdim, unpol_mstart, H5T_IEEE_F64LE);
+  hdf5_write_array(taus, "tau_recheck", 2, unpol_fdim, unpol_start, unpol_fdim, unpol_mdim, unpol_mstart, H5T_IEEE_F64LE);
+  if (!unpol) hdf5_write_array(imageS, "pol_recheck", 3, pol_fdim, pol_start, pol_fdim, pol_mdim, pol_mstart, H5T_IEEE_F64LE);
+
+  // housekeeping
+  hdf5_close();
+}
+
 void dump(double image[], double imageS[], double taus[],
     const char *fname, double scale, double cam[NDIM],
-    double fovx, double fovy, size_t nx, size_t ny, Params *params, int nopol)
+    double fovx, double fovy, size_t nx, size_t ny, Params *params)
 {
+  int unpol = params->only_unpolarized;
+
   hdf5_create(fname);
 
   write_header(scale, cam, fovx, fovy, params);
@@ -202,14 +240,14 @@ void dump(double image[], double imageS[], double taus[],
   for (int i=0; i < params->nx; ++i) {
     for (int j=0; j < params->ny; ++j) {
       Ftot_unpol += image[i*ny+j] * scale;
-      if (!nopol) Ftot += imageS[(i*ny+j)*NIMG+0] * scale;
+      if (!unpol) Ftot += imageS[(i*ny+j)*NIMG+0] * scale;
     }
   }
 
   hdf5_set_directory("/");
   // output stuff
   hdf5_write_single_val(&Ftot_unpol, "Ftot_unpol", H5T_IEEE_F64LE);
-  if (!nopol) hdf5_write_single_val(&Ftot, "Ftot", H5T_IEEE_F64LE);
+  if (!unpol) hdf5_write_single_val(&Ftot, "Ftot", H5T_IEEE_F64LE);
   double nuLnu = 4. * M_PI * Ftot * dsource * dsource * JY * freqcgs;
   hdf5_write_single_val(&nuLnu, "nuLnu", H5T_IEEE_F64LE);
   nuLnu = 4. * M_PI * Ftot_unpol * dsource * dsource * JY * freqcgs;
@@ -224,7 +262,7 @@ void dump(double image[], double imageS[], double taus[],
 
   hdf5_write_array(image, "unpol", 2, unpol_fdim, unpol_start, unpol_fdim, unpol_mdim, unpol_start, H5T_IEEE_F64LE);
   hdf5_write_array(taus, "tau", 2, unpol_fdim, unpol_start, unpol_fdim, unpol_mdim, unpol_start, H5T_IEEE_F64LE);
-  if (!nopol) hdf5_write_array(imageS, "pol", 3, pol_fdim, pol_start, pol_fdim, pol_mdim, pol_start, H5T_IEEE_F64LE);
+  if (!unpol) hdf5_write_array(imageS, "pol", 3, pol_fdim, pol_start, pol_fdim, pol_mdim, pol_start, H5T_IEEE_F64LE);
 
   // housekeeping
   hdf5_close();

--- a/src/io.h
+++ b/src/io.h
@@ -18,9 +18,10 @@ void read_restart(const char *fname, double *tA, double *tB, double *last_img_ta
                   int *nopenimgs, int *nimg, int nconcurrentimgs, int s2,
                   double *target_times, int *valid_imgs, struct of_image *dimages);
 
+void dump_check(double image[], double imageS[], double taus[], Params *params, int skip);
 void dump(double image[], double imageS[], double taus[],
           const char *fname, double scale, double cam[NDIM],
-          double fovx, double fovy, size_t nx, size_t ny, Params *params, int nopol);
+          double fovx, double fovy, size_t nx, size_t ny, Params *params);
 void dump_var_along(int i, int j, int nstep, struct of_traj *traj, int nx, int ny,
                     double scale, double cam[NDIM], double fovx, double fovy, Params *params);
 

--- a/src/main.c
+++ b/src/main.c
@@ -189,6 +189,8 @@ int main(int argc, char *argv[])
     fprintf(stderr, "Running in check mode...\n");
   }
 
+  double initialization_time = omp_get_wtime() - time;
+
   // slow light
   if (SLOW_LIGHT) {
 
@@ -431,7 +433,7 @@ int main(int argc, char *argv[])
 
           }
         }
-
+    
         if (do_output) {
 
           // image, imageS, taus
@@ -793,7 +795,7 @@ int main(int argc, char *argv[])
   } // SLOW_LIGHT
 
   time = omp_get_wtime() - time;
-  fprintf(stderr, "Total wallclock time: %g s\n\n", time);
+  fprintf(stderr, "Total wallclock time: %g s (%g s)\n\n", time, initialization_time);
 
   return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -452,7 +452,7 @@ int main(int argc, char *argv[])
           }
 
           //fprintf(stderr, "saving image %d at t = %g\n", k, target_times[k]);
-          char dfname[256];
+          char dfname[256] = {0};
           snprintf(dfname, 255, params.outf, target_times[k]);
           dump(image, imageS, taus, dfname, scale, Xcam, fovx, fovy, nx, ny, &params, params.only_unpolarized);
           valid_images[k] = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -257,12 +257,12 @@ int main(int argc, char *argv[])
     // now create data structures for geodesics and light rays
     maxsteplength += 2;
     fprintf(stderr, "geodesic size = %g GB\n", 1. * sizeof(struct of_traj) * nx*ny * maxsteplength / 1024/1024/1024);
-    struct of_traj *dtraj = malloc(sizeof(*dtraj) * nx*ny * maxsteplength);
+    struct of_traj *dtraj = calloc(nx*ny * maxsteplength, sizeof(*dtraj));
 
     // TODO: if DTd is different, we'll have to calcluate this a different way
     int nconcurrentimgs = 2. + 1. * fabs(t0) / params.img_cadence;
     fprintf(stderr, "images size = %g GB\n", 1. * sizeof(struct of_image) * nx*ny * nconcurrentimgs / 1024/1024/1024);
-    struct of_image *dimage = malloc(sizeof(*dimage) * nx*ny * nconcurrentimgs);
+    struct of_image *dimage = calloc(nx*ny * nconcurrentimgs, sizeof(*dimage));
 
     // now populate the geodesic data structures
 #pragma omp parallel for schedule(dynamic,2) collapse(2)
@@ -306,8 +306,8 @@ int main(int argc, char *argv[])
     // initialize state
     int nimg = 0, nopenimgs = 0;
     double last_img_target = tA - tgeof;
-    double *target_times = malloc(sizeof(*target_times) * nconcurrentimgs);
-    int *valid_images = malloc(sizeof(*valid_images) * nconcurrentimgs);
+    double *target_times = calloc(nconcurrentimgs, sizeof(*target_times));
+    int *valid_images = calloc(nconcurrentimgs, sizeof(*valid_images));
     for (int i=0; i<nconcurrentimgs; ++i) valid_images[i] = 0;
 
     fprintf(stderr, "first image will be produced for t = %g\n", last_img_target);

--- a/src/model_radiation.c
+++ b/src/model_radiation.c
@@ -16,6 +16,7 @@
 #include "radiation.h"
 #include "coordinates.h"
 #include "geometry.h"
+#include "grid.h"
 #include "debug_tools.h"
 #include "par.h"
 #include "decs.h"
@@ -160,9 +161,8 @@ void jar_calc_dist(int dist, double X[NDIM], double Kcon[NDIM],
   get_model_fourv(X, Kcon, Ucon, Ucov, Bcon, Bcov);
 #if DEBUG
   if (isnan(Ucov[0])) {
-    void Xtoijk(double X[NDIM], int *i, int *j, int *k, double del[NDIM]);
-    int i,j,k;
-    double del[4];
+    int i = 0, j = 0, k = 0;
+    double del[4] = {0};
     Xtoijk(X, &i,&j,&k, del);
     fprintf(stderr, "UCOV[0] (%d,%d,%d) is nan! thread = %i\n", i,j,k, omp_get_thread_num());
     print_vector("Ucon", Ucon);

--- a/src/par.c
+++ b/src/par.c
@@ -191,7 +191,7 @@ void try_set_parameter(const char *word, const char *value, Params *params) {
 // sets default values for elements of params (if desired) and loads from par file 'fname'
 void load_par(const char *fname, Params *params) {
  
-  char line[256], word[256], value[256];
+  char line[256] = {0}, word[256] = {0}, value[256] = {0};
   FILE *fp = fopen(fname, "r");
 
   if (fp == NULL) {

--- a/src/par.c
+++ b/src/par.c
@@ -48,6 +48,7 @@ void load_par_from_argv(int argc, char *argv[], Params *params) {
   params->qu_conv = 0;
   params->quench_output = 0;
   params->only_unpolarized = 0;
+  params->perform_check = 0;
   params->old_centering = 0;
 
   params->emission_type = 4;
@@ -96,6 +97,7 @@ void load_par_from_argv(int argc, char *argv[], Params *params) {
   for (int i=0; i<argc; ++i) {
     if ( strcmp(argv[i], "-quench") == 0 ) params->quench_output = 1;
     else if ( strcmp(argv[i], "-unpol") == 0 ) params->only_unpolarized = 1;
+    else if ( strcmp(argv[i], "-check") == 0 ) params->perform_check = 1;
 
     // read parameter from command line
     if ( strlen(argv[i])>2 && argv[i][0]=='-' && argv[i][1]=='-' ) {

--- a/src/par.h
+++ b/src/par.h
@@ -28,6 +28,7 @@ typedef struct params_t {
   int qu_conv;          // Convention for Stokes Q,U.  0 (default) -> East of North (observer).  1 -> North of West
   int quench_output;    // Quench output, i.e. "quench" argument
   int only_unpolarized; // Unpolarized transport only
+  int perform_check;    // Output check & recheck images
 
   // Which e- energy distributions/emissivities to use
   int emission_type;

--- a/src/utils.c
+++ b/src/utils.c
@@ -13,7 +13,7 @@ void *malloc_rank1(size_t n1, size_t size)
 {
   void *A;
 
-  if ((A = malloc(n1 * size)) == NULL) {
+  if ((A = calloc(n1, size)) == NULL) {
     fprintf(stderr,"malloc failure in malloc_rank1\n");
     exit(123);
   }


### PR DESCRIPTION
after running once in "regular" mode and then again with the same arguments and an extra "-check" command line flag, test whether the image is internally consistent with something like 

```python
import numpy as np
import h5py

fname = "image.h5"

skip = 10

hfp = h5py.File(fname, 'r')
print("unpol check/recheck close?", np.allclose(hfp['unpol_check'], hfp['unpol_recheck']))
print("pol check/recheck close?", np.allclose(hfp['pol_check'], hfp['pol_recheck']))
print("tau check/recheck close?", np.allclose(hfp['tau_check'], hfp['tau_recheck']))

print("unpol in full resolution agrees?", np.allclose(hfp['unpol_check'], hfp['unpol'][::skip, ::skip]))
print("pol in full resolution agrees?", np.allclose(hfp['pol_check'], hfp['pol'][::skip, ::skip]))
print("tau in full resolution agrees?", np.allclose(hfp['tau_check'], hfp['tau'][::skip, ::skip]))

hfp.close()
```