### PR TITLE
add command line argument to target mdot

### DIFF
--- a/model/iharm/model.c
+++ b/model/iharm/model.c
@@ -38,6 +38,8 @@ double U_unit;
 double B_unit;
 double Te_unit;
 
+double target_mdot = 0.0;  // if this value > 0, use to renormalize M_unit &c.
+
 // MOLECULAR WEIGHTS
 static double Ne_factor = 1.;  // e.g., used for He with 2 protons+neutrons per 2 electrons
 static double mu_i, mu_e, mu_tot;
@@ -128,6 +130,7 @@ void try_set_model_parameter(const char *word, const char *value)
   // assume params is populated
   set_by_word_val(word, value, "MBH", &MBH_solar, TYPE_DBL);
   set_by_word_val(word, value, "M_unit", &M_unit, TYPE_DBL);
+  set_by_word_val(word, value, "mdot", &target_mdot, TYPE_DBL);
 
   set_by_word_val(word, value, "dump", (void *)fnam, TYPE_STR);
 
@@ -1521,6 +1524,20 @@ void load_hamr_data(int n, char *fnam, int dumpidx, int verbose)
   MdotEdd_dump = Mdotedd;
   Ladv_dump =  Ladv;
 
+  if (target_mdot > 0) {
+    fprintf(stderr, "resetting M_unit to match target_mdot = %g\n", target_mdot);
+
+    double current_mdot = Mdot_dump/MdotEdd_dump;
+    fprintf(stderr, "was %g is now %g\n", M_unit, M_unit * fabs(target_mdot / current_mdot));
+    M_unit *= fabs(target_mdot / current_mdot);
+
+    set_units();
+  }
+
+  Mdot_dump = -dMact*M_unit/T_unit;
+  MdotEdd_dump = Mdotedd;
+  Ladv_dump =  Ladv;
+
   if (verbose == 2) {
     fprintf(stderr,"dMact: %g [code]\n",dMact);
     fprintf(stderr,"Ladv: %g [code]\n",Ladv_dump);
@@ -1700,6 +1717,20 @@ void load_koral_data(int n, char *fnam, int dumpidx, int verbose)
   dMact /= 21. ;
   Ladv *= dx[3]*dx[2] ;
   Ladv /= 21. ;
+
+  Mdot_dump = -dMact*M_unit/T_unit;
+  MdotEdd_dump = Mdotedd;
+  Ladv_dump =  Ladv;
+
+  if (target_mdot > 0) {
+    fprintf(stderr, "resetting M_unit to match target_mdot = %g\n", target_mdot);
+
+    double current_mdot = Mdot_dump/MdotEdd_dump;
+    fprintf(stderr, "was %g is now %g\n", M_unit, M_unit * fabs(target_mdot / current_mdot));
+    M_unit *= fabs(target_mdot / current_mdot);
+
+    set_units();
+  }
 
   Mdot_dump = -dMact*M_unit/T_unit;
   MdotEdd_dump = Mdotedd;
@@ -1941,6 +1972,20 @@ void load_iharm_data(int n, char *fnam, int dumpidx, int verbose)
   dMact /= 21. ;
   Ladv *= dx[3]*dx[2] ;
   Ladv /= 21. ;
+
+  Mdot_dump = -dMact*M_unit/T_unit;
+  MdotEdd_dump = Mdotedd;
+  Ladv_dump =  Ladv;
+
+  if (target_mdot > 0) {
+    fprintf(stderr, "resetting M_unit to match target_mdot = %g\n", target_mdot);
+
+    double current_mdot = Mdot_dump/MdotEdd_dump;
+    fprintf(stderr, "was %g is now %g\n", M_unit, M_unit * fabs(target_mdot / current_mdot));
+    M_unit *= fabs(target_mdot / current_mdot);
+
+    set_units();
+  }
 
   Mdot_dump = -dMact*M_unit/T_unit;
   MdotEdd_dump = Mdotedd;

--- a/model/iharm/model.c
+++ b/model/iharm/model.c
@@ -154,6 +154,11 @@ void try_set_model_parameter(const char *word, const char *value)
   set_by_word_val(word, value, "dump_max", &dumpmax, TYPE_INT);
   set_by_word_val(word, value, "dump_skip", &dumpskip, TYPE_INT);
   dumpidx = dumpmin;
+
+  // override parameters based on input
+  if (target_mdot > 0.) {
+    M_unit = 1.;
+  }
 }
 
 // Advance through dumps until we are closer to the next set
@@ -1525,10 +1530,10 @@ void load_hamr_data(int n, char *fnam, int dumpidx, int verbose)
   Ladv_dump =  Ladv;
 
   if (target_mdot > 0) {
-    fprintf(stderr, "resetting M_unit to match target_mdot = %g\n", target_mdot);
+    fprintf(stderr, "Resetting M_unit to match target_mdot = %g ", target_mdot);
 
     double current_mdot = Mdot_dump/MdotEdd_dump;
-    fprintf(stderr, "was %g is now %g\n", M_unit, M_unit * fabs(target_mdot / current_mdot));
+    fprintf(stderr, "... is now %g\n", M_unit * fabs(target_mdot / current_mdot));
     M_unit *= fabs(target_mdot / current_mdot);
 
     set_units();
@@ -1723,10 +1728,10 @@ void load_koral_data(int n, char *fnam, int dumpidx, int verbose)
   Ladv_dump =  Ladv;
 
   if (target_mdot > 0) {
-    fprintf(stderr, "resetting M_unit to match target_mdot = %g\n", target_mdot);
+    fprintf(stderr, "Resetting M_unit to match target_mdot = %g ", target_mdot);
 
     double current_mdot = Mdot_dump/MdotEdd_dump;
-    fprintf(stderr, "was %g is now %g\n", M_unit, M_unit * fabs(target_mdot / current_mdot));
+    fprintf(stderr, "... is now %g\n", M_unit * fabs(target_mdot / current_mdot));
     M_unit *= fabs(target_mdot / current_mdot);
 
     set_units();
@@ -1932,7 +1937,8 @@ void load_iharm_data(int n, char *fnam, int dumpidx, int verbose)
         for (int l=0; l<NDIM; ++l) bsq += bcon[l] * bcov[l];
         data[n]->b[i][j][k] = sqrt(bsq) * B_unit;
 
-        if(i <= 21) { dMact += g * data[n]->p[KRHO][i][j][k] * ucon[1];; }
+
+        if(i <= 21) { dMact += g * data[n]->p[KRHO][i][j][k] * ucon[1]; }
         if(i >= 21 && i < 41 && 0) Ladv += g * data[n]->p[UU][i][j][k] * ucon[1] * ucov[0];
         if(i <= 21) Ladv += g * data[n]->p[UU][i][j][k] * ucon[1] * ucov[0];
 
@@ -1978,10 +1984,10 @@ void load_iharm_data(int n, char *fnam, int dumpidx, int verbose)
   Ladv_dump =  Ladv;
 
   if (target_mdot > 0) {
-    fprintf(stderr, "resetting M_unit to match target_mdot = %g\n", target_mdot);
+    fprintf(stderr, "Resetting M_unit to match target_mdot = %g ", target_mdot);
 
     double current_mdot = Mdot_dump/MdotEdd_dump;
-    fprintf(stderr, "was %g is now %g\n", M_unit, M_unit * fabs(target_mdot / current_mdot));
+    fprintf(stderr, "... is now %g\n",M_unit * fabs(target_mdot / current_mdot));
     M_unit *= fabs(target_mdot / current_mdot);
 
     set_units();


### PR DESCRIPTION
If specified, this choice overrides M_unit. For now, it's still necessary to set a "trial" non-zero M_unit so that the code has a (non-zero) fiducial value of mdot to compare the target mdot against. This requirement could be removed in the future by automatically setting M_unit = 1 if mdot > 0. Thoughts, @bprather ?