### PR TITLE
Reintroduce Dexter rhoV with grtrans mitigation

### DIFF
--- a/src/model_radiation.c
+++ b/src/model_radiation.c
@@ -37,9 +37,7 @@
 #define E_LEUNG          5
 #define E_CUSTOM        10
 // Rotation
-#define ROT_OLD         11
-#define ROT_PIECEWISE   12
-#define ROT_SHCHERBAKOV 13
+#define ROT_DEXTER      11
 // Debugging/internal
 #define E_UNPOL         15
 
@@ -298,7 +296,9 @@ void jar_calc_dist(int dist, int pol, double X[NDIM], double Kcon[NDIM],
     }
 
     // ROTATIVITIES
-    paramsM.dexter_fit = 0;  // Don't use the Dexter rhoV, as it's unstable at low temperature
+    if (dist != ROT_DEXTER) {
+      paramsM.dexter_fit = 0;  // Don't use the Dexter rhoV, as it's unstable at low temperature
+    }
     *rQ = rho_nu_fit(&paramsM, paramsM.STOKES_Q) * nu;
     *rU = rho_nu_fit(&paramsM, paramsM.STOKES_U) * nu;
     *rV = rho_nu_fit(&paramsM, paramsM.STOKES_V) * nu;


### PR DESCRIPTION
Rotativity solutions for transport should correctly recover the low-temperature (non-relativistic) solution for Faraday rotation.  However, there are various ways of transitioning from a fit designed to be broadly applicable down to the low-T limit.

This exists because for the polarized comparison, I wanted to directly compare low-temperature rotativity behavior from various codes.  `grtrans`, for example, generally uses the fits outlined in the `grtrans` paper -- however, it has a somewhat interesting 3-part smooth transition to the non-relativistic limit, which `ipole` did not originally capture when using these functions.

Since it now behaves well (and quite similarly overall to the default Shcherbakov fit), this PR re-introduces the Dexter rhoV fit as a runtime option (previously, it could not be enabled at all).  Basically, I found it lying around in a testing branch and figured it might be a net benefit to have upstream as a reference or comparison option.