### PR TITLE
histogram of emission

### DIFF
--- a/model/iharm/example.par
+++ b/model/iharm/example.par
@@ -77,3 +77,7 @@ trace 0
 trace_stride 1
 # Trace file name
 trace_outf trace.h5
+
+# Histogram of origin of observed emissivity 
+histo 0
+histo_outf histo.h5

--- a/scripts/hist-Inu-weighted.py
+++ b/scripts/hist-Inu-weighted.py
@@ -1,0 +1,142 @@
+"""
+
+  You probably want to use this file ...
+
+  2019.01.16
+
+"""
+
+import os
+import sys
+import h5py
+import numpy as np
+import matplotlib as mpl
+mpl.use('Agg')
+import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
+import pyharm
+
+# set parameters here
+rlow = 1.
+rhigh = 80.
+thetae_mode = "MIXED" # "FIXED" "MIXED" "NATIVE"  (only MIXED implemented right now)
+sinth = 1./2
+
+
+# no need to touch anything below this line
+
+QE = 4.80320680e-10  # cgs
+CL = 2.99792458e10   # cgs
+ME = 9.1093826e-28   # cgs
+MP = 1.67262171e-24  # cgs
+
+def plthist(title,fname,data,wgts,dolog=True,nbins=100,vmin=None,vmax=None,ymin=None,ymax=None):
+  plt.close('all')
+  if vmin is None: vmin = data.min()
+  if vmax is None: vmax = data.max()
+  plt.hist(data,weights=wgts,log=dolog,bins=np.logspace(np.log10(vmin),np.log10(vmax),nbins))
+  plt.xscale('log')
+  if ymin is not None: plt.ylim(bottom=ymin)
+  if ymax is not None: plt.ylim(top=ymax)
+  plt.title(title)
+  plt.savefig(fname)
+
+def colorbar(mappable):
+  """ the way matplotlib colorbar should have been implemented """
+  from mpl_toolkits.axes_grid1 import make_axes_locatable
+  ax = mappable.axes
+  fig = ax.figure
+  divider = make_axes_locatable(ax)
+  cax = divider.append_axes("right", size="5%", pad=0.05)
+  return fig.colorbar(mappable, cax=cax)
+
+def get_ucon(U, gcon, gcov):
+  N1 = U.shape[0]
+  N2 = U.shape[1]
+  N3 = U.shape[2]
+  alpha = 1. / np.sqrt(-gcon[:,:,:,0,0])
+  gamma = np.sqrt(1. + np.einsum('abci,abci->abc',np.einsum('abcij,abci->abcj',gcov[:,:,:,1:,1:],U),U))
+  ucon = np.zeros((N1,N2,N3,4))
+  ucon[:,:,:,1:] = U - gamma[:,:,:,None] * alpha[:,:,:,None] * gcon[:,:,:,0,1:]
+  ucon[:,:,:,0] = gamma / alpha
+  return ucon
+
+if __name__ == "__main__":
+
+  # set these here
+  dump_fname = "tests/test-resources/sample_dump_SANE_a+0.94_MKS_0900.h5"
+  zone_fname = "histo.h5"
+  imag_fname = "image.h5"
+
+  # load grid values (for computation of four-vector quantities)
+  dump = pyharm.load_dump(dump_fname)
+
+  # load from dump file
+  print("loading dump file now ...")
+  hfp = h5py.File(dump_fname,'r')
+  N1 = hfp["header"]["n1"][()]
+  N2 = hfp["header"]["n2"][()]
+  N3 = hfp["header"]["n3"][()]
+  startx1 = hfp["header"]["geom"]["startx1"][()]
+  dx1 = hfp["header"]["geom"]["dx1"][()]
+  gam = hfp["header"]["gam"][()]
+  game = 4./3
+  gamp = 5./3
+  hfp.close()
+  (RHO, UU, U, B, ucon, ucov, bcon, bcov) = dump['rho'],  dump['u'],  dump['uvec'],  dump['Bvec'],  dump['ucon'],  dump['ucov'],  dump['bcon'],  dump['bcov']
+  print("done!")
+
+  # get units
+  with h5py.File(imag_fname,'r') as imag:
+    Lunit = imag["header"]["units"]["L_unit"][()]
+    Munit = imag["header"]["units"]["M_unit"][()]
+    Tunit = imag["header"]["units"]["T_unit"][()]
+    scale = imag["header"]["scale"][()]
+
+  RHOunit = Munit/np.power(Lunit,3.)
+  Bunit = CL * np.sqrt(4.*np.pi*RHOunit)
+
+  # calculate physical quantities
+  BSQ = np.einsum('iabc,iabc->abc',bcon,bcov)
+  BETA = UU*(gam-1.)/0.5/BSQ
+  BETASQ = np.power(BETA,2.)
+  TRAT = rhigh*BETASQ/(1.+BETASQ) + rlow*BETASQ/(1.+BETASQ)
+  THETAE = None
+  if thetae_mode == "MIXED":
+    THETAE = UU/RHO * MP/ME * (game-1.)*(gamp-1.)/((gamp-1.)+(game-1.)*TRAT)
+  NUS = QE * np.sqrt(BSQ)*Bunit * THETAE*THETAE * sinth / (9.*np.pi*ME*CL)
+  SYNCH_X = 230.e+9 / NUS
+
+  # load from zone file
+  with h5py.File(zone_fname,'r') as zones:
+    zdata = zones["data"][()] * np.power(230.e9, 3.) * scale
+
+  # generate geometry
+  X1i,X2i,X3i = np.meshgrid(range(N1),range(N2),range(N3))
+  X1i = X1i.transpose((1,0,2))
+  X2i = X2i.transpose((1,0,2))
+  X3i = X3i.transpose((1,0,2))
+  r = np.exp(np.linspace(startx1,startx1+dx1*N1,N1))
+  h = np.linspace(0,np.pi,N2) # TODO: make this right
+  p = np.linspace(0,2.*np.pi,N3)
+  R,H,P = np.meshgrid(r,h,p)
+  R = R.transpose((1,0,2))
+  H = H.transpose((1,0,2))
+  P = P.transpose((1,0,2))
+
+  os.makedirs("imgs", exist_ok=True)
+  # r
+  plthist("R [M]","imgs/r-hist.png",R.flatten(),zdata.flatten(),ymin=1.e-4,ymax=1,vmin=2,vmax=100)
+
+  # B
+  plthist("B [cgs]","imgs/b-hist.png",np.sqrt(BSQ.flatten())*Bunit,zdata.flatten(),vmin=1.e-2,vmax=1.e+2,ymin=1.e-10)
+
+  # rho
+  plthist("RHO [cgs]","imgs/rho-hist.png",RHO.flatten()*RHOunit,zdata.flatten())
+
+  # Thetae
+  plthist("THETAE","imgs/thetae-hist.png",THETAE.flatten(),zdata.flatten(),vmin=1.e-3,vmax=1.e4)
+  
+  # x = nu / nu_s
+  # nus = e B Thetae^2 Sin[th] / (9 Pi me c)
+  plthist("nu/nus","imgs/x-hist.png",SYNCH_X.flatten(),zdata.flatten(),vmin=1.e-5,vmax=1.e+10)

--- a/src/hdf5_utils.c
+++ b/src/hdf5_utils.c
@@ -562,3 +562,14 @@ int hdf5_read_full_array(void *data, const char *name, size_t rank, hsize_t *dim
   for (int i=0; i<rank; i++) start[i] = 0;
   return hdf5_write_array(data, name, rank, dims, start, dims, dims, start, hdf5_type);
 }
+
+// Ripped from old h5io.c, for histogramming
+void h5io_add_data_dbl_3ds(hid_t fid, const char *path, hsize_t n1, hsize_t n2, hsize_t n3, double data[])
+{
+  hsize_t dims[3] = { n1, n2, n3 };
+  hid_t dataspace_id = H5Screate_simple(3, dims, NULL);
+  hid_t dataset_id = H5Dcreate2(fid, path, H5T_IEEE_F64LE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
+  H5Dclose(dataset_id);
+  H5Sclose(dataspace_id);
+}

--- a/src/hdf5_utils.h
+++ b/src/hdf5_utils.h
@@ -53,3 +53,5 @@ int hdf5_write_str_list(const void *data, const char *name, size_t strlen, size_
 int hdf5_add_attr(const void *att, const char *att_name, const char *data_name, hsize_t hdf5_type);
 int hdf5_add_units(const char *name, const char *unit);
 
+// Old h5io.c functions
+void h5io_add_data_dbl_3ds(hid_t fid, const char *path, hsize_t n1, hsize_t n2, hsize_t n3, double data[]);

--- a/src/io.c
+++ b/src/io.c
@@ -8,6 +8,7 @@
 #include "decs.h"
 #include "coordinates.h"
 #include "geometry.h"
+#include "grid.h"
 #include "ipolarray.h"
 #include "radiation.h"
 #include "par.h"
@@ -539,4 +540,14 @@ void dump_var_along(int i, int j, int nstep, struct of_traj *traj, int nx, int n
   free(econ); free(ecov);
 
   hdf5_close();
+}
+
+void write_histo(Params *params) {
+  hid_t histo_fid = H5Fcreate(params->histo_outf, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  if (histo_fid < 0) {
+    fprintf(stderr, "! unable to open/create hdf5 zone output file.\n");
+    exit(-3);
+  }
+  h5io_add_data_dbl_3ds(histo_fid, "/data", N1, N2, N3, visible_emission_histogram);
+  H5Fclose(histo_fid);
 }

--- a/src/io.h
+++ b/src/io.h
@@ -25,4 +25,6 @@ void dump(double image[], double imageS[], double taus[],
 void dump_var_along(int i, int j, int nstep, struct of_traj *traj, int nx, int ny,
                     double scale, double cam[NDIM], double fovx, double fovy, Params *params);
 
+void write_histo(Params *params);
+
 #endif // IO_H

--- a/src/ipolarray.h
+++ b/src/ipolarray.h
@@ -54,4 +54,7 @@ void complex_tetrad_to_coord_rank2(double complex T_tetrad[NDIM][NDIM],
     double Econ[NDIM][NDIM],
     double complex T_coord[NDIM][NDIM]);
 
+// Pointer for keeping/writing a histogram of zone contents
+extern double *visible_emission_histogram;
+
 #endif /* IPOLARRAY_H */

--- a/src/main.c
+++ b/src/main.c
@@ -12,6 +12,7 @@
 #include "tetrads.h"
 #include "geometry.h"
 #include "geodesics.h"
+#include "grid.h"
 #include "image.h"
 #include "io.h"
 #include "ipolarray.h"
@@ -76,10 +77,12 @@ int main(int argc, char *argv[])
   double freq, scale;
   double DX, DY, fovx, fovy;
 
+  int omp_nthreads = 1;
 #pragma omp parallel
-  if (omp_get_thread_num() == 0) {
-    fprintf(stderr, "nthreads = %d\n", omp_get_num_threads());
-  }
+{
+  omp_nthreads = omp_get_num_threads();
+}
+  fprintf(stderr, "nthreads = %d\n", omp_nthreads);
 
   // load values from parameter file. handle all actual
   // model parameter comprehension in the model/* files
@@ -191,6 +194,11 @@ int main(int argc, char *argv[])
       fprintf(stderr, "Could not allocate image memory!");
       exit(-1);
     }
+  }
+
+  if (params.histo) {
+    // allocate memory for emission histogram
+    visible_emission_histogram = calloc(N1*N2*N3, sizeof(*visible_emission_histogram));
   }
 
   if (params.perform_check) {
@@ -801,6 +809,8 @@ int main(int argc, char *argv[])
       }
     }
   } // SLOW_LIGHT
+
+  if (params.histo) write_histo(&params);
 
   time = omp_get_wtime() - time;
   fprintf(stderr, "Total wallclock time: %g s (%g s)\n\n", time, initialization_time);

--- a/src/par.c
+++ b/src/par.c
@@ -94,6 +94,10 @@ void load_par_from_argv(int argc, char *argv[], Params *params) {
   // but hey, no warnings
   sscanf("trace.h5", "%s", (char *) (void *) params->trace_outf);
 
+  params->histo = 0;
+  params->histo_polar = 0;
+  sscanf("histo.h5", "%s", (char *) (void *) params->histo_outf);
+
   // process each command line argument
   for (int i=0; i<argc; ++i) {
     if ( strcmp(argv[i], "-quench") == 0 ) params->quench_output = 1;
@@ -186,6 +190,10 @@ void try_set_parameter(const char *word, const char *value, Params *params) {
   set_by_word_val(word, value, "trace_i", &(params->trace_i), TYPE_INT);
   set_by_word_val(word, value, "trace_j", &(params->trace_j), TYPE_INT);
   set_by_word_val(word, value, "trace_outf", (void *)(params->trace_outf), TYPE_STR);
+
+  set_by_word_val(word, value, "histo", &(params->histo), TYPE_INT);
+  set_by_word_val(word, value, "histo_polar", &(params->histo_polar), TYPE_INT);
+  set_by_word_val(word, value, "histo_outf", (void *)(params->histo_outf), TYPE_STR);
 
   // Let models add/parse their own parameters we don't understand
   try_set_model_parameter(word, value);

--- a/src/par.h
+++ b/src/par.h
@@ -62,6 +62,10 @@ typedef struct params_t {
   int trace_stride;
   int trace_i, trace_j;
   const char trace_outf[STRLEN];
+
+  // Histogram observer-visible emission from each zone
+  int histo, histo_polar;
+  const char histo_outf[STRLEN];
 } Params;
 
 // modify this to set default values


### PR DESCRIPTION
Port forward GNW's old zone-by-zone emission histogramming code. Just drops any (signed) change in intensity from unpolarized transport (dI) into a bin corresponding to the nearest zone (via Xtoijk).

Implementation adds a static global array of grid size, accessible to any file importing grid.h.  Not modular but not invasive...