### PR TITLE
Fix setting final dump time in Slow Light

### DIFF
--- a/model/iharm/model.c
+++ b/model/iharm/model.c
@@ -71,7 +71,8 @@ static double Ladv_dump;
 
 static int reverse_field = 0;
 
-double tf;
+// Need to share this with main.c!
+extern double tf;
 
 // MAYBES
 //static double t0;

--- a/src/main.c
+++ b/src/main.c
@@ -58,8 +58,8 @@ void lininterp2(double *image, double *imageS, double *taus, size_t i1, size_t j
 // TODO use this more.  Are long=only or upscaled ops faster?
 static inline size_t imgindex(size_t n, size_t i, size_t j, size_t nx, size_t ny) {return (n*nx + i)*ny + j;}
 
-// global variables. TODO scope into main
-static double tf = 0.;
+// global variables. TODO scope into main and pass to/from model
+double tf = 0.;
 
 Params params = { 0 };
 


### PR DESCRIPTION
Slow light was segfaulting or failing to run, depending on parameters. Turns out model.c and main.c had separate copies of `tf`, resulting in hijinks.

I haven't checked that it produces valid images, but at least this version runs.