### PR TITLE
fix: renamed preprocessor conditionals for SLOW_LIGHT

### DIFF
--- a/model/meshblocks/model.c
+++ b/model/meshblocks/model.c
@@ -12,6 +12,7 @@
 #include "simcoords.h"  // For interpolating arbitrary grids
 #include "par.h"
 #include "utils.h"
+#include "model_params.h"
 
 #include "debug_tools.h"
 
@@ -477,7 +478,7 @@ double mb_interp_scalar_time(int mb, double x, double y, double z, double ****va
 {
   double vA = mb_interp_scalar(mb, x, y, z, varA);
 
-#if SLOWLIGHT
+#if SLOW_LIGHT
   double vB = mb_interp_scalar(mb, x, y, z, varB);
   return tfac*vA + (1. - tfac)*vB;
 #endif

--- a/src/grid.c
+++ b/src/grid.c
@@ -4,6 +4,7 @@
 #include "simcoords.h"
 #include "geometry.h"
 #include <math.h>
+#include "model_params.h"
 
 int N1, N2, N3;
 
@@ -48,7 +49,7 @@ double interp_scalar_time(double X[NDIM], double ***varA, double ***varB, double
 {
   double vA = interp_scalar(X, varA);
 
-#if SLOWLIGHT
+#if SLOW_LIGHT
   double vB = interp_scalar(X, varB);
   return tfac*vA + (1. - tfac)*vB;
 #endif


### PR DESCRIPTION
This PR fixes a major bug in slowlight where the function `interp_scalar_time` was executed wrongly due to incorrect preprocessor conditional directives.

As a result, plasma variables were not interpolated across dump files. Instead, the code returned values from the earliest loaded dump between the two that should be interpolated, leading to incorrect results without triggering any warnings or runtime errors.

The issue has been corrected by fixing the conditional compilation directive controlling slowlight. I have verified that it compiles successfully, but haven't tested runtime behavior.